### PR TITLE
SCRS-8897 added feature to set environment for handoffs

### DIFF
--- a/app/config/FrontendConfig.scala
+++ b/app/config/FrontendConfig.scala
@@ -22,6 +22,7 @@ object FrontendConfig extends ServicesConfig {
 
   lazy val self = getConfString("comp-reg-frontend.url", throw new Exception("Could not find config for comp-reg-frontend url"))
   lazy val selfFull = getConfString("comp-reg-frontend.fullurl", self)
+  lazy val selfFullLegacy = getConfString("comp-reg-frontend.legacyfullurl", selfFull)
 
   lazy val incorporationInfoUrl = baseUrl("incorp-info")
 }

--- a/app/forms/test/FeatureSwitchForm.scala
+++ b/app/forms/test/FeatureSwitchForm.scala
@@ -24,7 +24,8 @@ object FeatureSwitchForm {
 
   val form = Form(
     mapping(
-      "firstHandOff" -> nonEmptyText
+      "firstHandOff" -> nonEmptyText,
+      "legacyEnv" -> nonEmptyText
     )(FeatureSwitch.apply)(FeatureSwitch.unapply)
   )
 }

--- a/app/models/test/FeatureSwitch.scala
+++ b/app/models/test/FeatureSwitch.scala
@@ -18,7 +18,7 @@ package models.test
 
 import play.api.libs.json.Json
 
-case class FeatureSwitch(firstHandOff: String)
+case class FeatureSwitch(firstHandOff: String, legacyEnv: String)
 
 object FeatureSwitch {
   implicit val format = Json.format[FeatureSwitch]

--- a/app/services/HandOffNavigator.scala
+++ b/app/services/HandOffNavigator.scala
@@ -37,7 +37,10 @@ trait HandOffNavigator extends CommonService with SCRSExceptions {
   _: ServicesConfig =>
 
   val navModelMongo : NavModelRepository
-  val compRegFrontendUrl = FrontendConfig.selfFull
+  def compRegFrontendUrl = SCRSFeatureSwitches.legacyEnv.enabled match {
+    case false => FrontendConfig.selfFull
+    case true => FrontendConfig.selfFullLegacy
+  }
 
   private def buildUrl(call: Call) = {
     val url = call.url
@@ -45,14 +48,14 @@ trait HandOffNavigator extends CommonService with SCRSExceptions {
     s"$compRegFrontendUrl${url.substring(0, url.length - stripLen)}"
   }
 
-  val corporationTaxDetails = buildUrl(routes.CorporationTaxDetailsController.corporationTaxDetails(""))
-  val aboutYouUrl = buildUrl(routes.BasicCompanyDetailsController.returnToAboutYou(""))
+  def corporationTaxDetails = buildUrl(routes.CorporationTaxDetailsController.corporationTaxDetails(""))
+  def aboutYouUrl = buildUrl(routes.BasicCompanyDetailsController.returnToAboutYou(""))
 
-  val regularPaymentsBackUrl = buildUrl(routes.BusinessActivitiesController.businessActivitiesBack(""))
-  val summaryUrl = buildUrl(routes.CorporationTaxSummaryController.corporationTaxSummary(""))
+  def regularPaymentsBackUrl = buildUrl(routes.BusinessActivitiesController.businessActivitiesBack(""))
+  def summaryUrl = buildUrl(routes.CorporationTaxSummaryController.corporationTaxSummary(""))
 
-  val returnSummaryUrl = buildUrl(routes.IncorporationSummaryController.returnToCorporationTaxSummary(""))
-  val confirmationURL = buildUrl(routes.RegistrationConfirmationController.registrationConfirmation(""))
+  def returnSummaryUrl = buildUrl(routes.IncorporationSummaryController.returnToCorporationTaxSummary(""))
+  def confirmationURL = buildUrl(routes.RegistrationConfirmationController.registrationConfirmation(""))
 
   val postSignInCall = controllers.reg.routes.SignInOutController.postSignIn(None)
   val postSignInUrl = postSignInCall.url

--- a/app/utils/FeatureSwitch.scala
+++ b/app/utils/FeatureSwitch.scala
@@ -84,15 +84,18 @@ object SCRSFeatureSwitches extends SCRSFeatureSwitches {
 trait SCRSFeatureSwitches {
 
   val COHO: String
+  val LEGACY_ENV: String = "legacyEnv"
 
   def cohoFirstHandOff = FeatureSwitch.getProperty(COHO)
   def businessActivitiesHandOff = FeatureSwitch.getProperty("businessActivitiesHandOff")
   def paye = FeatureSwitch.getProperty("paye")
+  def legacyEnv = FeatureSwitch.getProperty(LEGACY_ENV)
 
   def apply(name: String): Option[FeatureSwitch] = name match {
-    case "cohoFirstHandOff" => Some(cohoFirstHandOff)
+    case COHO => Some(cohoFirstHandOff)
     case "businessActivitiesHandOff" => Some(businessActivitiesHandOff)
     case "paye" => Some(paye)
+    case LEGACY_ENV => Some(legacyEnv)
     case _ => None
   }
 }

--- a/app/views/test/FeatureSwitch.scala.html
+++ b/app/views/test/FeatureSwitch.scala.html
@@ -22,6 +22,13 @@
                 '_groupClass -> "form-group inline"
             )
 
+            <h2>Legacy Env</h2>
+            @inputRadioGroup(
+            featureSwitchForm("legacyEnv"),
+            Seq("true" -> "DCD (Legacy)", "false" -> "AWS"),
+            '_labelClass -> "block-label radio-label",
+            '_groupClass -> "form-group inline"
+            )
             <div class="form-group">
                 <button class="button btn" role="button" id="next">Submit</button>
             </div>

--- a/test/controllers/TestEndpointControllerSpec.scala
+++ b/test/controllers/TestEndpointControllerSpec.scala
@@ -228,7 +228,7 @@ class TestEndpointControllerSpec extends SCRSSpec with SCRSFixtures with Mockito
   "updateFeatureSwitch" should {
 
     "submit a valid feature switch form" in new Setup {
-      val request = FakeRequest().withFormUrlEncodedBody("firstHandOff" -> "true")
+      val request = FakeRequest().withFormUrlEncodedBody("firstHandOff" -> "true", "legacyEnv" -> "true")
       val result = controller.updateFeatureSwitch()(request)
 
       status(result) shouldBe OK


### PR DESCRIPTION
To enable support, needs a config entry e.g. `microservice.services.comp-reg-frontend.legacyfullurl: https://point-to-the-environment/`

Set the feature using http://localhost:9970/register-your-company/test-only/feature-switch or, if necessary, via config `feature.legacyEnv: 'true'`

Feature **must** be set to the correct value **before** the hand-off model is created on first hand-off.