### PR TITLE
Update confirmation page to adopt larger font size for accessibility

### DIFF
--- a/app/views/reg/CancelPaye.scala.html
+++ b/app/views/reg/CancelPaye.scala.html
@@ -10,34 +10,30 @@
 
 <a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
 
-<div class="grid-row">
-    <div class="column-two-thirds">
-        <header class="page-header">
-            <h1 id="main-heading" class="heading-xlarge">@Messages("page.reg.cancelpaye.heading")</h1>
-        </header>
-        <div class="notice">
-            <div class="important-notice">
-                @Messages("page.reg.cancelpaye.warning")<br>
-                <BR>
-            </div>
+    <header class="page-header">
+        <h1 id="main-heading" class="heading-xlarge">@Messages("page.reg.cancelpaye.heading")</h1>
+    </header>
+    <div class="notice">
+        <div class="important-notice">
+            @Messages("page.reg.cancelpaye.warning")<br>
+            <BR>
         </div>
-        @form(action = controllers.reg.routes.CancelPayeController.submit()) {
-            <div class="form-group">
-                @inputRadioGroup(
-                    cancelPaye("cancelPaye"),
-                    Seq(("true",Messages("page.reg.cancelpaye.radioYesLabel")),("false",Messages("page.reg.cancelpaye.radioNoLabel"))),
-                    '_fieldsetId -> "cancel-paye",
-                    '_groupClass -> "inline",
-                    '_labelClass -> "block-label radio-label",
-                    '_legend -> Messages("page.reg.cancelpaye.heading"),
-                    '_legendClass -> "visuallyhidden"
-                )
-            </div>
-
-            <div class="form-group">
-                <button class="button" type="submit" id="next">@Messages("common.button.save")</button>
-            </div>
-        }
     </div>
-</div>
+    @form(action = controllers.reg.routes.CancelPayeController.submit()) {
+        <div class="form-group">
+            @inputRadioGroup(
+                cancelPaye("cancelPaye"),
+                Seq(("true",Messages("page.reg.cancelpaye.radioYesLabel")),("false",Messages("page.reg.cancelpaye.radioNoLabel"))),
+                '_fieldsetId -> "cancel-paye",
+                '_groupClass -> "inline",
+                '_labelClass -> "block-label radio-label",
+                '_legend -> Messages("page.reg.cancelpaye.heading"),
+                '_legendClass -> "visuallyhidden"
+            )
+        </div>
+
+        <div class="form-group">
+            <button class="button" type="submit" id="next">@Messages("common.button.save")</button>
+        </div>
+    }
 }

--- a/app/views/reg/Confirmation.scala.html
+++ b/app/views/reg/Confirmation.scala.html
@@ -7,15 +7,18 @@
 
 @main_template(title = Messages("page.reg.Confirmation.title"), mainClass = None) {
     <div class="govuk-box-highlight">
-        <h1 id="heading-application-submitted" class="form-title heading-large" style="color: #fff">@Messages("page.reg.Confirmation.heading")</h1>
-
-        <ul class="list-bullet heading-small" style="text-align: left; width:65%; margin: 0 auto;">
-            <p align="center">@Messages("page.reg.Confirmation.your.limited")<br><strong id="ltd-ref" class="heading-small">@confirmationRefs.transactionId</strong></p>
-            <p align="center">@Messages("page.reg.Confirmation.your.refnumber")<br><strong id="ackref" class="heading-small">@confirmationRefs.acknowledgementReference</strong></p>
-        </ul>
+        <h1 id="heading-application-submitted" class="heading-xlarge">@Messages("page.reg.Confirmation.heading")</h1>
+        <p class="font-large">
+            @Messages("page.reg.Confirmation.your.limited")<br>
+            <strong id="ltd-ref">@confirmationRefs.transactionId</strong>
+        </p>
+        <p class="font-large">
+            @Messages("page.reg.Confirmation.your.refnumber")<br>
+            <strong id="ackref">@confirmationRefs.acknowledgementReference</strong></p>
+        </p>
     </div>
-    <br>
-    <h2 id="next-steps">@Messages("page.reg.Confirmation.next-steps")</h2>
+
+    <h2 class="heading-medium" id="next-steps">@Messages("page.reg.Confirmation.next-steps")</h2>
 
     <p>@Messages("page.reg.Confirmation.next-steps.receive")</p>
     <ul class="list list-bullet">
@@ -25,9 +28,7 @@
 
     <div>
         <p id="certificate">@Messages("page.reg.Confirmation.next-steps.certificate")</p>
-
         <p id="security">@Messages("page.reg.Confirmation.next-steps.security")</p>
-
         <p id="keep-safe-text">@Messages("page.reg.Confirmation.keep-safe.text")</p>
     </div>
 

--- a/app/views/reg/Summary.scala.html
+++ b/app/views/reg/Summary.scala.html
@@ -34,6 +34,7 @@
 
     <a id="back" class="link-back" href="@controllers.reg.routes.SummaryController.back()">@Messages("common.button.back")</a>
 
+<<<<<<< HEAD
     <h1 id="main-heading" class="heading-xlarge">@Messages("page.reg.summary.heading")</h1>
 
     <h2 class="heading-24">@Messages("page.reg.summary.page")</h2>

--- a/app/views/reg/Summary.scala.html
+++ b/app/views/reg/Summary.scala.html
@@ -34,7 +34,6 @@
 
     <a id="back" class="link-back" href="@controllers.reg.routes.SummaryController.back()">@Messages("common.button.back")</a>
 
-<<<<<<< HEAD
     <h1 id="main-heading" class="heading-xlarge">@Messages("page.reg.summary.heading")</h1>
 
     <h2 class="heading-24">@Messages("page.reg.summary.page")</h2>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -31,7 +31,7 @@ application.langs="en,cy"
 play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 www.google-analytics.com data:"
 
 assets {
-  version = "2.249.0"
+  version = "2.251.1"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
 }

--- a/conf/messages
+++ b/conf/messages
@@ -74,13 +74,8 @@ page.reg.CreateAccount.email.error=Enter a valid email address
 #Confirmation
 page.reg.Confirmation.title=Application submitted
 page.reg.Confirmation.heading=Application submitted
-page.reg.Confirmation.you-have=You have:
 page.reg.Confirmation.your.limited=Your limited company reference number is
 page.reg.Confirmation.your.refnumber=Your Corporation Tax reference number is
-page.reg.Confirmation.bullet.ltd=applied to set up a limited company
-page.reg.Confirmation.bullet.inc=applied to be registered for Corporation Tax
-page.reg.Confirmation.bullet.payment=made a payment of
-page.reg.Confirmation.ref-number=reference number
 page.reg.Confirmation.next-steps=What happens next?
 page.reg.Confirmation.next-steps.email=You''ll receive an email within 2 working days letting you know the outcome of your application
 page.reg.Confirmation.next-steps.certificate=If your application is successful, the second email will have the company''s registration number and Certificate of Incorporation.

--- a/public/stylesheets/scrs-styling.css
+++ b/public/stylesheets/scrs-styling.css
@@ -1,2 +1,22 @@
 @import 'form-validation.css';
 @import 'header.css';
+
+
+/* All the styles below can be deleted when HMRC AF moves to version 3 and/or 4 */
+@media (min-width: 641px) {
+	/*
+		Temporary reset width to 2/3's overidding HMRC AF which sets the width explicitly at 61.666667%
+		https://github.com/hmrc/assets-frontend/blob/3610585baeb96bb4ad9d73d20cfb73864e095b50/assets/scss/layouts/_page.scss#L60
+	*/
+	.content__body {
+		width: 66.66%;
+	}
+
+	/*
+		Overriding HMRC AF that has 'temporary' which is overriding govuk_frontend_static
+		https://github.com/hmrc/assets-frontend/blob/3610585baeb96bb4ad9d73d20cfb73864e095b50/assets/scss/base/typography/_headings.scss#L41
+	*/
+	.heading-medium {
+    margin-top: 1.875em !important;
+  }
+}

--- a/public/stylesheets/scrs-styling.css
+++ b/public/stylesheets/scrs-styling.css
@@ -1,17 +1,8 @@
 @import 'form-validation.css';
 @import 'header.css';
 
-
 /* All the styles below can be deleted when HMRC AF moves to version 3 and/or 4 */
 @media (min-width: 641px) {
-	/*
-		Temporary reset width to 2/3's overidding HMRC AF which sets the width explicitly at 61.666667%
-		https://github.com/hmrc/assets-frontend/blob/3610585baeb96bb4ad9d73d20cfb73864e095b50/assets/scss/layouts/_page.scss#L60
-	*/
-	.content__body {
-		width: 66.66%;
-	}
-
 	/*
 		Overriding HMRC AF that has 'temporary' which is overriding govuk_frontend_static
 		https://github.com/hmrc/assets-frontend/blob/3610585baeb96bb4ad9d73d20cfb73864e095b50/assets/scss/base/typography/_headings.scss#L41


### PR DESCRIPTION
This commit also introduces a couple of tidy up changes too:
• Update list to p.font-large as per GOV.UK examples
http://govuk-elements.herokuapp.com/colour/#examples
https://govuk-prototype-kit.herokuapp.com/docs/examples/confirmation-page
• Update header with class .heading-xlarge and remove inline styles
• Remove superflouos br's and update h2 class
• Add temporary local style overrides with comments
• Remove redundant .column-two-thirds from summary page
• Update messages to match prototype
http://business-reg-prototype.herokuapp.com/1-58-0/incorporation/ConfirmV2
• Update PrinciplePlaceOfBusiness.scala.html to use local error helper to fix styling

### Before
<img width="1006" alt="screen shot 2017-09-22 at 14 32 21" src="https://user-images.githubusercontent.com/1692222/30751409-2a08c64a-9fb1-11e7-81da-3e25c3a06714.png">

### After
<img width="1006" alt="screen shot 2017-09-22 at 14 31 30" src="https://user-images.githubusercontent.com/1692222/30751426-3530ad94-9fb1-11e7-9b12-1d340e854917.png">

