### PR TITLE
Column classes refactor

### DIFF
--- a/app/views/reg/AccountingDates.scala.html
+++ b/app/views/reg/AccountingDates.scala.html
@@ -18,11 +18,9 @@
 }
 
 @notPlanningToYetHiddenContent = {
-    <!--<br>-->
     <div class="notice">
        <div class="important-notice">
            @Messages("page.reg.accountingDates.warning")
-           <!--<BR>-->
        </div>
     </div>
 }
@@ -31,21 +29,21 @@
 
 <a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
 
-<div class="grid-row">
-        @errorSummary(
-            Messages("common.errorSummary.label"),
-            accountingDatesForm,
-            Seq("notFuture", "dateNotFoundDay","dateNotFoundMonth","dateNotFoundYear","invalidDay","invalidMonth","invalidYear","invalidDate")
-        )
+    @errorSummary(
+        Messages("common.errorSummary.label"),
+        accountingDatesForm,
+        Seq("notFuture", "dateNotFoundDay","dateNotFoundMonth","dateNotFoundYear","invalidDay","invalidMonth","invalidYear","invalidDate")
+    )
 
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.accountingDates.heading")</h1>
-        </header>
-        <div class ="form-group">
-            <p class="lede">@Messages("page.reg.accountingDates.lede1")</p>
-        </div>
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.accountingDates.heading")</h1>
+    </header>
+    <div class ="form-group">
+        <p class="lede">@Messages("page.reg.accountingDates.lede1")</p>
+    </div>
 
-        @form(action = AccountingDatesController.submit()) {
+    @form(action = AccountingDatesController.submit()) {
+        <div class="form-group">
             @inputRadioGroupHidden(
                 accountingDatesForm("businessStartDate"),
                 Seq("whenRegistered" -> Messages("page.reg.accountingDates.radioOne"),
@@ -59,12 +57,10 @@
                 '_legend -> Messages("page.reg.accountingDates.heading"),
                 '_legendClass -> "visuallyhidden"
             )
+        </div>
 
-            <br>
-
-            <div class="form-group">
-                <button class="btn button" id="next">@Messages("common.button.snc")</button>
-            </div>
-        }
-</div>
+        <div class="form-group">
+            <button class="btn button" id="next">@Messages("common.button.snc")</button>
+        </div>
+    }
 }

--- a/app/views/reg/CancelPaye.scala.html
+++ b/app/views/reg/CancelPaye.scala.html
@@ -22,19 +22,21 @@
             </div>
         </div>
         @form(action = controllers.reg.routes.CancelPayeController.submit()) {
+            <div class="form-group">
+                @inputRadioGroup(
+                    cancelPaye("cancelPaye"),
+                    Seq(("true",Messages("page.reg.cancelpaye.radioYesLabel")),("false",Messages("page.reg.cancelpaye.radioNoLabel"))),
+                    '_fieldsetId -> "cancel-paye",
+                    '_groupClass -> "inline",
+                    '_labelClass -> "block-label radio-label",
+                    '_legend -> Messages("page.reg.cancelpaye.heading"),
+                    '_legendClass -> "visuallyhidden"
+                )
+            </div>
 
-        @inputRadioGroup(
-            cancelPaye("cancelPaye"),
-            Seq(("true",Messages("page.reg.cancelpaye.radioYesLabel")),("false",Messages("page.reg.cancelpaye.radioNoLabel"))),
-            '_fieldsetId -> "cancel-paye",
-            '_groupClass -> "form-group inline",
-            '_labelClass -> "block-label radio-label",
-            '_legend -> Messages("page.reg.cancelpaye.heading"),
-            '_legendClass -> "visuallyhidden"
-        )
-        <div class="form-group">
-            <button class="button" type="submit" id="next">@Messages("common.button.save")</button>
-        </div>
+            <div class="form-group">
+                <button class="button" type="submit" id="next">@Messages("common.button.save")</button>
+            </div>
         }
     </div>
 </div>

--- a/app/views/reg/CompanyContactDetails.scala.html
+++ b/app/views/reg/CompanyContactDetails.scala.html
@@ -22,14 +22,14 @@
 
     @form(action = controllers.reg.routes.CompanyContactDetailsController.submit()) {
 
-    <div class ="form-field">
-        @input(
-            contactDetails("contactName"),
-            '_label -> Messages("page.reg.company-contact-details.label-one"),
-            '_labelDataAttributes -> "id=contactNameLabel",
-            '_inputClass -> "form-control form-control--block"
-        )
-    </div>
+        <div class ="form-field">
+            @input(
+                contactDetails("contactName"),
+                '_label -> Messages("page.reg.company-contact-details.label-one"),
+                '_labelDataAttributes -> "id=contactNameLabel",
+                '_inputClass -> "form-control form-control--block"
+            )
+        </div>
         <div class="indent">
             <p id="helpMessage1">@Messages("page.reg.company-contact-details.helpMessage1")</p>
         </div>
@@ -64,7 +64,6 @@
             </div>
         </fieldset>
 
-        <br>
         <div class="form-group">
             <button class="btn button" id="next">@Messages("common.button.snc")</button>
         </div>

--- a/app/views/reg/CompletionCapacity.scala.html
+++ b/app/views/reg/CompletionCapacity.scala.html
@@ -20,41 +20,34 @@
 
     <a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
 
-    <div class="grid-row">
-        <div class="column-one-third">
+    @errorSummary(
+        Messages("common.errorSummary.label"),
+        aboutYou
+    )
 
-            @errorSummary(
-                Messages("common.errorSummary.label"),
-                aboutYou
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.AboutYou.heading")</h1>
+    </header>
+
+    @form(action = controllers.reg.routes.CompletionCapacityController.submit()) {
+        <div class="form-group">
+            @inputRadioGroupHidden(
+                aboutYou("completionCapacity"),
+                Seq("director"          -> Messages("page.reg.AboutYou.radio1"),
+                    "company secretary" -> Messages("page.reg.AboutYou.radio2"),
+                    "agent"             -> Messages("page.reg.AboutYou.radio3"),
+                    "other"             -> Messages("page.reg.AboutYou.radio4")),
+                Seq("other" -> otherHidden),
+                '_idHidden -> "other",
+                '_classHidden -> "panel panel-indent",
+                '_labelClass -> "block-label radio-label",
+                '_legend -> Messages("page.reg.AboutYou.heading"),
+                '_legendClass -> "visuallyhidden"
             )
-
-            <header class="page-header">
-                <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.AboutYou.heading")</h1>
-            </header>
-
-
-
-        @form(action = controllers.reg.routes.CompletionCapacityController.submit()) {
-                <div class="form-group">
-                    @inputRadioGroupHidden(
-                        aboutYou("completionCapacity"),
-                        Seq("director"          -> Messages("page.reg.AboutYou.radio1"),
-                            "company secretary" -> Messages("page.reg.AboutYou.radio2"),
-                            "agent"             -> Messages("page.reg.AboutYou.radio3"),
-                            "other"             -> Messages("page.reg.AboutYou.radio4")),
-                        Seq("other" -> otherHidden),
-                        '_idHidden -> "other",
-                        '_classHidden -> "panel panel-indent",
-                        '_labelClass -> "block-label radio-label",
-                        '_legend -> Messages("page.reg.AboutYou.heading"),
-                        '_legendClass -> "visuallyhidden"
-                    )
-                </div>
-
-                <div class="form-group">
-                    <button class="btn button" id="next">@Messages("common.button.snc")</button>
-                </div>
-            }
         </div>
-    </div>
+
+        <div class="form-group">
+            <button class="btn button" id="next">@Messages("common.button.snc")</button>
+        </div>
+    }
 }

--- a/app/views/reg/Dashboard.scala.html
+++ b/app/views/reg/Dashboard.scala.html
@@ -203,230 +203,220 @@
 
 @main_template(title = Messages("page.reg.Dashboard.title"), mainClass = None) {
 
-    <style>
-        td.right {
-            text-align: right;
+    <a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
+
+    <style type="text/css">
+        td:first-child {
+            width: 50%;
         }
-         td.bottom {
-            text-align: center;
-        }
-        .check-your-answers td {
-            font-size: 19px;
-            margin: 0;
-            vertical-align: middle;
+        td:only-child {
+            width: 100%;
         }
     </style>
 
-    <a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
-
     <div class="form-group">
+        <header>
+            <h1 class="heading-xlarge" id="main-heading">@Messages("page.reg.Dashboard.heading")</h1>
+        </header>
 
-        <div class="grid-row">
-            <div class="column-two-thirds">
-                <header>
-                    <h1 class="heading-xlarge" id="main-heading">@Messages("page.reg.Dashboard.heading")</h1>
-                </header>
+        <!--<h2 class="heading-medium">@dash.companyName</h2>-->
+        <h2 class="heading-medium" id="subheading">@Messages("page.reg.Dashboard.incorporation")</h2>
 
-                <!--<h2 class="heading-medium">@dash.companyName</h2>-->
-                <h2 class="heading-medium" id="subheading">@Messages("page.reg.Dashboard.incorporation")</h2>
+        <div class="form-group">
 
-            <div class="form-group">
+            <table class="check-your-answers">
 
-                <table class="check-your-answers">
+                <tbody>
+                    <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                        <td class="check-your-answers">@Messages("page.reg.Dashboard.status")</td>
+                        <td id="incorpStatusText">@incorpStatus</td>
+                    </tr>
+                </tbody>
 
+                @if(dash.incDash.status == "held") {
                     <tbody>
                         <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                            <td class="check-your-answers">@Messages("page.reg.Dashboard.status")</td>
-                            <td id="incorpStatusText" style="width:50%">@incorpStatus</td>
+                            <td>@Messages("page.reg.Dashboard.submissionDate")</td>
+                            <td id="incorpSubmissionDate">@dash.incDash.submissionDate</td>
+
                         </tr>
                     </tbody>
 
-                    @if(dash.incDash.status == "held") {
-                        <tbody>
-                            <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                                <td>@Messages("page.reg.Dashboard.submissionDate")</td>
-                                <td id="incorpSubmissionDate" style="width:50%">@dash.incDash.submissionDate</td>
+                    <tbody>
+                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                            <td>@Messages("page.reg.Dashboard.ref")</td>
+                            <td id="incorpTransID">@dash.incDash.transId</td>
 
-                            </tr>
-                        </tbody>
+                        </tr>
+                    </tbody>
 
-                        <tbody>
-                            <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                                <td>@Messages("page.reg.Dashboard.ref")</td>
-                                <td id="incorpTransID" style="width:50%">@dash.incDash.transId</td>
+                    <tbody>
+                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                            <td>@Messages("page.reg.Dashboard.paymentRef")</td>
+                            <td id="incorpPaymentReference">@dash.incDash.paymentRef</td>
 
-                            </tr>
-                        </tbody>
+                        </tr>
+                    </tbody>
 
-                        <tbody>
-                            <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                                <td>@Messages("page.reg.Dashboard.paymentRef")</td>
-                                <td id="incorpPaymentReference" style="width:50%">@dash.incDash.paymentRef</td>
+                    <tbody>
+                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                           <td id="incorpSubmittedText" colspan="2">@Messages("page.reg.Dashboard.incSubmittedLineOne")</td>
 
-                            </tr>
-                        </tbody>
+                        </tr>
+                    </tbody>
 
-                        <tbody>
-                            <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                               <td id="incorpSubmittedText" colspan="2">@Messages("page.reg.Dashboard.incSubmittedLineOne")</td>
+                } else {
+                    <tbody>
+                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                            <td>@Messages("page.reg.Dashboard.crn")</td>
+                            <td id="crn">@dash.incDash.crn</td>
+                        </tr>
+                    </tbody>
 
-                            </tr>
-                        </tbody>
-
-                    } else {
-                        <tbody>
-                            <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                                <td>@Messages("page.reg.Dashboard.crn")</td>
-                                <td id="crn">@dash.incDash.crn</td>
-                            </tr>
-                        </tbody>
-
-                        <tbody>
-                            <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                                <td id="incorpRegisteredText" colspan="2">@Messages("page.reg.Dashboard.incChangeDetailsPrefix") <a href="@cohoSignIn">@Messages("page.reg.Dashboard.incChangeDetailsLinkText")</a>@Messages("page.reg.Dashboard.incChangeDetailsSuffix")</td>
-                            </tr>
-                        </tbody>
-                    }
-                </table>
+                    <tbody>
+                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                            <td id="incorpRegisteredText" colspan="2">@Messages("page.reg.Dashboard.incChangeDetailsPrefix") <a href="@cohoSignIn">@Messages("page.reg.Dashboard.incChangeDetailsLinkText")</a>@Messages("page.reg.Dashboard.incChangeDetailsSuffix")</td>
+                        </tr>
+                    </tbody>
+                }
+            </table>
 
 
-                <!--Corporation Block-->
-                <h3 class="heading-medium" id="corporationSubheading">@Messages("page.reg.Dashboard.corporation")</h3>
-                <table class="check-your-answers">
+            <!--Corporation Block-->
+            <h3 class="heading-medium" id="corporationSubheading">@Messages("page.reg.Dashboard.corporation")</h3>
+            <table class="check-your-answers">
 
-                    <!-- CT Status -->
+                <!-- CT Status -->
+                <thead>
+                    <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                        <td>@Messages("page.reg.Dashboard.status")</td>
+                        <td  id="ctStatusText">@ctStatus</td>
+
+                    </tr>
+                </thead>
+                <!-- CT Status end -->
+
+                @if(dash.incDash.status == "held") {
                     <thead>
-                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                            <td>@Messages("page.reg.Dashboard.status")</td>
-                            <td  id="ctStatusText" style="width:50%">@ctStatus</td>
+                    <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                        <td>@Messages("page.reg.Dashboard.ref")</td>
+                        <td id="ackRef">@dash.incDash.ackRef</td>
 
-                        </tr>
+                    </tr>
                     </thead>
-                    <!-- CT Status end -->
-
-                    @if(dash.incDash.status == "held") {
-                        <thead>
-                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                            <td>@Messages("page.reg.Dashboard.ref")</td>
-                            <td id="ackRef" style="width:50%">@dash.incDash.ackRef</td>
-
-                        </tr>
-                        </thead>
 
 
-                        <thead>
-                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                            <td id="ctPendingText" colspan="2">@Messages("page.reg.Dashboard.CTPendingLineOne")</td>
+                    <thead>
+                    <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                        <td id="ctPendingText" colspan="2">@Messages("page.reg.Dashboard.CTPendingLineOne")</td>
 
-                        </tr>
-                        </thead>
-                    } @if(dash.incDash.status == "submitted"){
-                        <thead>
-                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                            <td>@Messages("page.reg.Dashboard.submissionDate")</td>
-                            <td id="ctSubmissionDate" style="width:50%">@dash.incDash.ctSubmissionDate</td>
+                    </tr>
+                    </thead>
+                } @if(dash.incDash.status == "submitted"){
+                    <thead>
+                    <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                        <td>@Messages("page.reg.Dashboard.submissionDate")</td>
+                        <td id="ctSubmissionDate">@dash.incDash.ctSubmissionDate</td>
 
-                        </tr>
-                        </thead>
+                    </tr>
+                    </thead>
 
-                        <thead>
-                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                            <td>@Messages("page.reg.Dashboard.ref")</td>
-                            <td id="submittedAckRef" style="width:50%">@dash.incDash.ackRef</td>
+                    <thead>
+                    <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                        <td>@Messages("page.reg.Dashboard.ref")</td>
+                        <td id="submittedAckRef">@dash.incDash.ackRef</td>
 
-                        </tr>
-                        </thead>
+                    </tr>
+                    </thead>
 
-                        <thead>
-                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                            <td colspan="2">
-                                <p id="CTifSuccess">@Messages("page.reg.Dashboard.CTSubmittedLineOne")</p>
-                                <ul class="list list-bullet">
-                                    <li>@Messages("page.reg.Dashboard.CTSubmittedLineTwo")</li>
-                                    <li>@Messages("page.reg.Dashboard.CTSubmittedLineThree")</li>
-                                </ul>
-                            </td>
-
-                        </tr>
-                        </thead>
-                    } @if(dash.incDash.status == "acknowledged"){
                     <thead>
                     <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
                         <td colspan="2">
-                            <p>@Messages("page.reg.Dashboard.CTRegistered")</p>
+                            <p id="CTifSuccess">@Messages("page.reg.Dashboard.CTSubmittedLineOne")</p>
+                            <ul class="list list-bullet">
+                                <li>@Messages("page.reg.Dashboard.CTSubmittedLineTwo")</li>
+                                <li>@Messages("page.reg.Dashboard.CTSubmittedLineThree")</li>
+                            </ul>
                         </td>
 
                     </tr>
                     </thead>
-                    }
-                    @if(dash.incDash.ackRefStatus.fold(false)(_ == "06")){
+                } @if(dash.incDash.status == "acknowledged"){
+                <thead>
+                <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                    <td colspan="2">
+                        <p>@Messages("page.reg.Dashboard.CTRegistered")</p>
+                    </td>
 
-                        <thead>
-                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                            <td>@Messages("page.reg.Dashboard.wycd")</td>
-                            <td colspan="2" style="width:50%"><a href="https://online.hmrc.gov.uk/registration/newbusiness/introduction">
-                                @Messages("page.reg.Dashboard.CTUnsuccessful")</a></td>
-                        </tr>
-                        </thead>
-                    }
-                </table>
-
-                <!--PAYE Block-->
-                @if(dash.payeDash.status != "notEnabled"){
-                    <h4 class="heading-medium" id="payeSubheading">@Messages("page.reg.Dashboard.PAYE.subHeading")</h4>
-
-                    @if(dash.payeDash.status == "notStarted"){
-                        <table class="check-your-answers">
-
-                            @payeMap
-                            <!-- PAYE Status -->
-                            <thead>
-                            <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                                <td>@Messages("page.reg.Dashboard.status")</td>
-                                <td  id="payeStatusText" style="width:50%">@payeStatus</td>
-
-                            </tr>
-                            </thead>
-                            <!-- PAYE Status end -->
-                        </table>
-                    } else {
-                        <table class="check-your-answers">
-
-                            <!-- PAYE Status -->
-                            <thead>
-                            <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                                <td>@Messages("page.reg.Dashboard.status")</td>
-                                <td  id="payeStatusText" style="width:50%">@payeStatus</td>
-
-                            </tr>
-                            </thead>
-                            <!-- PAYE Status end -->
-
-                            @payeMap
-                        </table>
-                    }
+                </tr>
+                </thead>
                 }
+                @if(dash.incDash.ackRefStatus.fold(false)(_ == "06")){
 
-                <!--VAT Block-->
-                @if(showVATBlock){
-                <h4 class="heading-medium" id="vatSubheading">@Messages("page.reg.Dashboard.VAT.title")</h4>
-                <table class="check-your-answers">
-                    <!-- VAT Status -->
                     <thead>
                     <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
-                        <td>@Messages("page.reg.Dashboard.status")</td>
-                        <td id="vatStatusText" style="width:50%"><a id="vatUrl" href="https://online.hmrc.gov.uk/registration/newbusiness/introduction">@Messages("page.reg.Dashboard.VAT.registerText")</a></td>
-
+                        <td>@Messages("page.reg.Dashboard.wycd")</td>
+                        <td colspan="2"><a href="https://online.hmrc.gov.uk/registration/newbusiness/introduction">
+                            @Messages("page.reg.Dashboard.CTUnsuccessful")</a></td>
                     </tr>
                     </thead>
-                    <!-- VAT Status end -->
-                    @doYouNeedToRegisterForVATHelp
-                </table>
                 }
-            </div>
+            </table>
+
+            <!--PAYE Block-->
+            @if(dash.payeDash.status != "notEnabled"){
+                <h4 class="heading-medium" id="payeSubheading">@Messages("page.reg.Dashboard.PAYE.subHeading")</h4>
+
+                @if(dash.payeDash.status == "notStarted"){
+                    <table class="check-your-answers">
+
+                        @payeMap
+                        <!-- PAYE Status -->
+                        <thead>
+                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                            <td>@Messages("page.reg.Dashboard.status")</td>
+                            <td  id="payeStatusText">@payeStatus</td>
+
+                        </tr>
+                        </thead>
+                        <!-- PAYE Status end -->
+                    </table>
+                } else {
+                    <table class="check-your-answers">
+
+                        <!-- PAYE Status -->
+                        <thead>
+                        <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                            <td>@Messages("page.reg.Dashboard.status")</td>
+                            <td  id="payeStatusText">@payeStatus</td>
+
+                        </tr>
+                        </thead>
+                        <!-- PAYE Status end -->
+
+                        @payeMap
+                    </table>
+                }
+            }
+
+            <!--VAT Block-->
+            @if(showVATBlock){
+            <h4 class="heading-medium" id="vatSubheading">@Messages("page.reg.Dashboard.VAT.title")</h4>
+            <table class="check-your-answers">
+                <!-- VAT Status -->
+                <thead>
+                <tr class="tabular-data__cell--centred status--confirm-success" role ="row">
+                    <td>@Messages("page.reg.Dashboard.status")</td>
+                    <td id="vatStatusText"><a id="vatUrl" href="https://online.hmrc.gov.uk/registration/newbusiness/introduction">@Messages("page.reg.Dashboard.VAT.registerText")</a></td>
+
+                </tr>
+                </thead>
+                <!-- VAT Status end -->
+                @doYouNeedToRegisterForVATHelp
+            </table>
+            }
         </div>
     </div>
-</div>
 
 }
 

--- a/app/views/reg/IncompleteRegistration.scala.html
+++ b/app/views/reg/IncompleteRegistration.scala.html
@@ -4,32 +4,25 @@
 
 @main_template(title = Messages("page.reg.incompleteReg.title"), mainClass = None) {
 
-<a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
+    <a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
 
-<div class="grid-row">
-    <div class="column-one-third">
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.incompleteReg.heading")</h1>
-        </header>
-        <div class="notice">
-            <div class="important-notice">
-                @Messages("page.reg.incompleteReg.warning")<br>
-                <BR>
-            </div>
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.incompleteReg.heading")</h1>
+    </header>
+    <div class="notice">
+        <div class="important-notice">
+            @Messages("page.reg.incompleteReg.warning")<br>
+            <BR>
         </div>
-        <div class="form-group">
-            <p id="description-one">@Messages("page.reg.incompleteReg.description.one")</p>
-
-            <p id="description-two">@Messages("page.reg.incompleteReg.description.two")</p>
-            </br>
-            @form(action = controllers.reg.routes.IncompleteRegistrationController.submit()) {
-            <div class="form-group">
-                <button class="button-get-started" role="button" id="next">@Messages("common.button.sign-in")</button>
-            </div>
-            }
-        </div>
-        </br>
     </div>
+    <div class="form-group">
+        <p id="description-one">@Messages("page.reg.incompleteReg.description.one")</p>
 
-</div>
+        <p id="description-two">@Messages("page.reg.incompleteReg.description.two")</p>
+    </div>
+    @form(action = controllers.reg.routes.IncompleteRegistrationController.submit()) {
+    <div class="form-group">
+        <button class="button-get-started" role="button" id="next">@Messages("common.button.sign-in")</button>
+    </div>
+    }
 }

--- a/app/views/reg/PrinciplePlaceOfBusiness.scala.html
+++ b/app/views/reg/PrinciplePlaceOfBusiness.scala.html
@@ -1,7 +1,7 @@
 @(ppobForm: Form[PPOBChoice], ROAddress: NewAddress, PPOBAddress: Option[NewAddress])(implicit request: Request[_], messages: Messages)
 
-@import uk.gov.hmrc.play.views.html.helpers.{form, errorSummary, input}
-@import views.html.helpers.inputRadioGroup
+@import uk.gov.hmrc.play.views.html.helpers.{form, input}
+@import views.html.helpers.{inputRadioGroup, errorSummary}
 
 @PPOBIsEqualToRO = @{PPOBAddress match {
     case Some(ppob) => ppob.isEqualTo(ROAddress)
@@ -12,40 +12,33 @@
 
     <a id="back" class="link-back" href="@controllers.reg.routes.PPOBController.back()">@Messages("common.button.back")</a>
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    @errorSummary(
+        Messages("common.errorSummary.label"),
+        ppobForm
+    )
 
-            @errorSummary(
-                Messages("common.errorSummary.label"),
-                ppobForm
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.ppob.heading")</h1>
+    </header>
+
+    <p>@Messages("page.reg.ppob.location")</p>
+    <p>@Messages("page.reg.ppob.mobileBusiness")</p>
+
+    @form(action = controllers.reg.routes.PPOBController.submit()) {
+        <div class="form-group">
+            @inputRadioGroup(
+                ppobForm("addressChoice"),
+                PPOBAddress.fold(Seq.empty[(String, String)])(PPOBAddr => Seq("PPOB" -> PPOBAddr.mkString))
+                  ++ (if(PPOBIsEqualToRO) Seq.empty[(String, String)] else Seq("RO" -> ROAddress.mkString))
+                  ++ Seq("Other" -> messages("page.reg.ppob.other")),
+                '_labelClass -> "block-label radio-label",
+                '_legend -> Messages("page.reg.ppob.heading"),
+                '_legendClass -> "visuallyhidden"
             )
-
-            <header class="page-header">
-                <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.ppob.heading")</h1>
-            </header>
-
-             <p>@Messages("page.reg.ppob.location")</p>
-             <p>@Messages("page.reg.ppob.mobileBusiness")</p>
-
-
-            @form(action = controllers.reg.routes.PPOBController.submit()) {
-                <div class="form-group">
-                    @inputRadioGroup(
-                        ppobForm("addressChoice"),
-                        PPOBAddress.fold(Seq.empty[(String, String)])(PPOBAddr => Seq("PPOB" -> PPOBAddr.mkString))
-                          ++ (if(PPOBIsEqualToRO) Seq.empty[(String, String)] else Seq("RO" -> ROAddress.mkString))
-                          ++ Seq("Other" -> messages("page.reg.ppob.other")),
-                        '_labelClass -> "block-label radio-label",
-                        '_legend -> Messages("page.reg.ppob.heading"),
-                        '_legendClass -> "visuallyhidden"
-                    )
-
-                    <br>
-                    <div class="form-group" id="nextButton">
-                        <button class="btn button" id="next" name="action" value="continue">@Messages("common.button.snc")</button>
-                    </div>
-                </div>
-            }
         </div>
-    </div>
+
+        <div class="form-group" id="nextButton">
+            <button class="btn button" id="next" name="action" value="continue">@Messages("common.button.snc")</button>
+        </div>
+    }
 }

--- a/app/views/reg/Questionnaire.scala.html
+++ b/app/views/reg/Questionnaire.scala.html
@@ -18,11 +18,9 @@
         Messages("common.errorSummary.label"), qForm
     )
 @form(action = controllers.reg.routes.QuestionnaireController.submit()){
-<div class="grid-row">
-    <div class="column-one-third">
 
-        <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.questionnaire.title")</h1>
-        <div id="trying_to_do">
+    <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.questionnaire.title")</h1>
+    <div id="trying_to_do" class="form-group">
         @inputRadioGroup(qForm("tryingToDo"),
             Seq("RegisterCompany_1" -> Messages("page.reg.questionnaire.q2.a1"),
                 "RegisterEmployer_2" -> Messages("page.reg.questionnaire.q2.a2"),
@@ -31,9 +29,8 @@
             '_labelClass -> "block-label",
             '_legend -> Messages("page.reg.questionnaire.q2"),
             '_legendClass -> "heading-medium")
-        </div>
-        <br/>
-
+    </div>
+    <div class="form-group">
         <div id="able_to_achieve">
             @inputRadioGroup(qForm("ableToAchieve"),
                 Seq("Yes_1" -> Messages("page.reg.questionnaire.q1.a1"),
@@ -46,76 +43,70 @@
         <div class="indent" style="display:none" id ="why_not_achieve">
             <label for="whyNotAchieveTb" class="heading-small">Why not?</label>
             <textarea cols="30" rows="4" class="form-control textarea--fullwidth" id="whyNotAchieveTb" name="whyNotAchieve">@qForm("whyNotAchieve").value</textarea>
-        <br/>
         </div>
-        <br/>
-
-        <div id="satisfaction">
-            @inputRadioGroup(
-            qForm("satisfaction"),
-            Seq("very_satisfied-5" -> Messages("page.reg.questionnaire.q3.a1"),
-                "satisfied-4" -> Messages("page.reg.questionnaire.q3.a2"),
-                "neither_satisfied_nor_dissatisfied-3" -> Messages("page.reg.questionnaire.q3.a3"),
-                "dissatisfied-2" -> Messages("page.reg.questionnaire.q3.a4"),
-                "very_dissatisfied-1" -> Messages("page.reg.questionnaire.q3.a5")
-            ),
-                '_labelAfter -> true,
-                '_labelClass -> "block-label",
-                '_legend -> Messages("page.reg.questionnaire.q3"),
-                '_legendClass -> "heading-medium"
-        )
-
-        </div>
-        <br/>
-
-        <div id="meet_needs">
-        @inputRadioGroup(
-            qForm("meetNeeds"),
-            Seq("10" -> "10 - Very well",
-                "9" -> "9",
-                "8" -> "8",
-                "7" -> "7",
-                "6" -> "6",
-                "5" -> "5",
-                "4" -> "4",
-                "3" -> "3",
-                "2" -> "2",
-                "1" -> "1 - Not well"
-            ),
-            '_labelClass -> "block-label",
-            '_labelAfter -> true,
-            '_legend -> Messages("page.reg.questionnaire.q4"),
-            '_legendClass -> "heading-medium")
-
-        </div>
-        <br/>
-        <div>
-        @inputRadioGroup(
-            qForm("recommendation"),
-            Seq("very_likely-5" -> Messages("page.reg.questionnaire.q5.a1"),
-                "likely-4" -> Messages("page.reg.questionnaire.q5.a2"),
-                "not_sure-3" -> Messages("page.reg.questionnaire.q5.a3"),
-                "unlikely-2" -> Messages("page.reg.questionnaire.q5.a4"),
-                "very_unlikely-1" -> Messages("page.reg.questionnaire.q5.a5")
-            ),
-            '_labelAfter -> true,
-            '_labelClass -> "block-label",
-            '_legend -> Messages("page.reg.questionnaire.q5"),
-            '_legendClass -> "heading-medium"
-        )
-        </div>
-
-
-        <div id ="improvements">
-            <label for="improvementsTb" class="heading-medium">@Messages("page.reg.questionnaire.q6")</label>
-
-            <textarea cols="30" rows="4" class="form-control textarea--fullwidth" id="improvementsTb" name="improvements">@qForm("improvements").value</textarea>
-        </div>
-        <div class="form-group">
-            <button class="button" role="button" id="next">@Messages("page.reg.questionnaire.send")</button>
-        </div>
-        }
     </div>
 
-</div>
+    <div id="satisfaction" class="form-group">
+        @inputRadioGroup(
+        qForm("satisfaction"),
+        Seq("very_satisfied-5" -> Messages("page.reg.questionnaire.q3.a1"),
+            "satisfied-4" -> Messages("page.reg.questionnaire.q3.a2"),
+            "neither_satisfied_nor_dissatisfied-3" -> Messages("page.reg.questionnaire.q3.a3"),
+            "dissatisfied-2" -> Messages("page.reg.questionnaire.q3.a4"),
+            "very_dissatisfied-1" -> Messages("page.reg.questionnaire.q3.a5")
+        ),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label",
+            '_legend -> Messages("page.reg.questionnaire.q3"),
+            '_legendClass -> "heading-medium"
+    )
+
+    </div>
+
+    <div id="meet_needs" class="form-group">
+    @inputRadioGroup(
+        qForm("meetNeeds"),
+        Seq("10" -> "10 - Very well",
+            "9" -> "9",
+            "8" -> "8",
+            "7" -> "7",
+            "6" -> "6",
+            "5" -> "5",
+            "4" -> "4",
+            "3" -> "3",
+            "2" -> "2",
+            "1" -> "1 - Not well"
+        ),
+        '_labelClass -> "block-label",
+        '_labelAfter -> true,
+        '_legend -> Messages("page.reg.questionnaire.q4"),
+        '_legendClass -> "heading-medium")
+    </div>
+
+    <div class="form-group">
+    @inputRadioGroup(
+        qForm("recommendation"),
+        Seq("very_likely-5" -> Messages("page.reg.questionnaire.q5.a1"),
+            "likely-4" -> Messages("page.reg.questionnaire.q5.a2"),
+            "not_sure-3" -> Messages("page.reg.questionnaire.q5.a3"),
+            "unlikely-2" -> Messages("page.reg.questionnaire.q5.a4"),
+            "very_unlikely-1" -> Messages("page.reg.questionnaire.q5.a5")
+        ),
+        '_labelAfter -> true,
+        '_labelClass -> "block-label",
+        '_legend -> Messages("page.reg.questionnaire.q5"),
+        '_legendClass -> "heading-medium"
+    )
+    </div>
+
+
+    <div id ="improvements" class="form-group">
+        <label for="improvementsTb" class="heading-medium">@Messages("page.reg.questionnaire.q6")</label>
+
+        <textarea cols="30" rows="4" class="form-control textarea--fullwidth" id="improvementsTb" name="improvements">@qForm("improvements").value</textarea>
+    </div>
+    <div class="form-group">
+        <button class="button" role="button" id="next">@Messages("page.reg.questionnaire.send")</button>
+    </div>
+    }
 }

--- a/app/views/reg/RegistrationUnsuccessful.scala.html
+++ b/app/views/reg/RegistrationUnsuccessful.scala.html
@@ -4,37 +4,32 @@
 
 @main_template(title = Messages("page.reg.registrationUnsuccessful.title"), mainClass = None) {
 
-<a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
+    <a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
 
-<div class="grid-row">
-    <div class="column-one-third">
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.registrationUnsuccessful.heading")</h1>
-        </header>
-        <div class="form-group">
-            <p id="company">@Messages("page.reg.registrationUnsuccessful.yourCompany")</p>
-            </br>
-            <h2 class="form-title heading-medium" id="sub-heading">@Messages("page.reg.registrationUnsuccessful.subHeading")</h2>
-        </div>
-        </div>
-        <div class="form-group">
-            <p id="description-one">@Messages("page.reg.registrationUnsuccessful.emailConfirmation")</p>
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.registrationUnsuccessful.heading")</h1>
+    </header>
+    <div class="form-group">
+        <p id="company">@Messages("page.reg.registrationUnsuccessful.yourCompany")</p>
+        </br>
+        <h2 class="form-title heading-medium" id="sub-heading">@Messages("page.reg.registrationUnsuccessful.subHeading")</h2>
+    </div>
+    <div class="form-group">
+        <p id="description-one">@Messages("page.reg.registrationUnsuccessful.emailConfirmation")</p>
 
 
-            @form(action = controllers.reg.routes.RegistrationUnsuccessfulController.submit()) {
+        @form(action = controllers.reg.routes.RegistrationUnsuccessfulController.submit()) {
             <p id="description-two">@Messages("page.reg.registrationUnsuccessful.detailsEntered")
                 <input value='@Messages("page.verification.verify-your-email.dropdown-link2")@Messages(".")' type="submit" class="link-style">
                 </input></p>
             <p id="description-three">@Messages("page.reg.registrationUnsuccessful.paymentRefund")</p>
             </br>
 
-            <div>
+            <div class="form-group">
                 <button class="btn button" id="next">@Messages("common.button.next")</button>
             </div>
-            }
-        </div>
+        }
     </div>
-
 }
 
 

--- a/app/views/reg/Summary.scala.html
+++ b/app/views/reg/Summary.scala.html
@@ -30,175 +30,171 @@
     }
 }
 
-@main_template(title = Messages("page.reg.summary.title"), mainClass = Some("full-width"), pageScripts = Some(Html(s"""<link rel="stylesheet" href="${routes.Assets.at("stylesheets/summary.css")}">"""))){
+@main_template(title = Messages("page.reg.summary.title"), pageScripts = Some(Html(s"""<link rel="stylesheet" href="${routes.Assets.at("stylesheets/summary.css")}">"""))){
 
     <a id="back" class="link-back" href="@controllers.reg.routes.SummaryController.back()">@Messages("common.button.back")</a>
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
-            <h1 id="main-heading" class="heading-xlarge">@Messages("page.reg.summary.heading")</h1>
+    <h1 id="main-heading" class="heading-xlarge">@Messages("page.reg.summary.heading")</h1>
 
-            <h2 class="heading-24">@Messages("page.reg.summary.page")</h2>
+    <h2 class="heading-24">@Messages("page.reg.summary.page")</h2>
+    <div class="form-group">
+        <table class="check-your-answers multiple-sections">
+            <caption id="applicantTitle" class="heading-medium">@Messages("page.reg.summary.heading.applicant")</caption>
+            <thead class="visuallyhidden">
+                <tr>
+                    <th>@Messages("page.reg.summary.header.question")</th>
+                    <th>@Messages("page.reg.summary.header.answer")</th>
+                    <th>@Messages("page.reg.summary.header.change")</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="question">@Messages("page.reg.summary.applicantText")</td>
+                    <td id="applicant" class="answer">@applicant.completionCapacity.capitalize</td>
+                    <td class="change"><a href="about-you" id="change-applicant">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.applicant.change")</span></a></td>
+                </tr>
+            </tbody>
+        </table>
 
-            <table class="check-your-answers multiple-sections">
-                <caption id="applicantTitle" class="heading-medium">@Messages("page.reg.summary.heading.applicant")</caption>
-                <thead class="visuallyhidden">
-                    <tr>
-                        <th>@Messages("page.reg.summary.header.question")</th>
-                        <th>@Messages("page.reg.summary.header.answer")</th>
-                        <th>@Messages("page.reg.summary.header.change")</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td class="question">@Messages("page.reg.summary.applicantText")</td>
-                        <td id="applicant" class="answer">@applicant.completionCapacity.capitalize</td>
-                        <td class="change"><a href="about-you" id="change-applicant">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.applicant.change")</span></a></td>
-                    </tr>
-                </tbody>
-            </table>
+        <table class="check-your-answers multiple-sections">
+            <caption id="companyNameTitle" class="heading-medium">@Messages("page.reg.summary.heading.one")</caption>
+            <thead class="visuallyhidden">
+                <tr>
+                    <th>@Messages("page.reg.summary.header.question")</th>
+                    <th>@Messages("page.reg.summary.header.answer")</th>
+                    <th>@Messages("page.reg.summary.header.change")</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="question">@Messages("page.reg.summary.companyNameText")</td>
+                    <td id="companyName" class="answer">@companyName</td>
+                    <td class="change">
+                        <a href='@controllers.reg.routes.SummaryController.summaryBackLink("company_name")' id="change-companyname">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.companyName.change")</span></a>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="question">@Messages("page.reg.summary.ROAddressText")</td>
 
-            <table class="check-your-answers multiple-sections">
-                <caption id="companyNameTitle" class="heading-medium">@Messages("page.reg.summary.heading.one")</caption>
-                <thead class="visuallyhidden">
-                    <tr>
-                        <th>@Messages("page.reg.summary.header.question")</th>
-                        <th>@Messages("page.reg.summary.header.answer")</th>
-                        <th>@Messages("page.reg.summary.header.change")</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td class="question">@Messages("page.reg.summary.companyNameText")</td>
-                        <td id="companyName" class="answer">@companyName</td>
-                        <td class="change">
-                            <a href='@controllers.reg.routes.SummaryController.summaryBackLink("company_name")' id="change-companyname">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.companyName.change")</span></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="question">@Messages("page.reg.summary.ROAddressText")</td>
+                    <td id="ROAddress" class="answer">
+                        @{if(s"${roAddress.premises} ${roAddress.address_line_1}".length <= 27) {
+                        formatAddress(s"${roAddress.premises} ${roAddress.address_line_1}")
+                        } else {
+                        formatAddress(roAddress.premises)
+                        formatAddress(roAddress.address_line_1)
+                        }}
+                        @formatAddress(roAddress.address_line_2.fold[String]("")(s => s ))
+                        @formatAddress(roAddress.locality)
+                        @formatAddress(roAddress.region.fold[String]("")(s => s ))
+                        @formatAddress(roAddress.postal_code.fold[String]("")(s => s ))
+                        @formatAddress(roAddress.country)
+                    </td>
+                    <td class="change">
+                        <a href='@controllers.reg.routes.SummaryController.summaryBackLink("company_address")' id="change-roaddress">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.ROAddress.change")</span></a>
+                    </td>
+                </tr>
 
-                        <td id="ROAddress" class="answer">
-                            @{if(s"${roAddress.premises} ${roAddress.address_line_1}".length <= 27) {
-                            formatAddress(s"${roAddress.premises} ${roAddress.address_line_1}")
-                            } else {
-                            formatAddress(roAddress.premises)
-                            formatAddress(roAddress.address_line_1)
-                            }}
-                            @formatAddress(roAddress.address_line_2.fold[String]("")(s => s ))
-                            @formatAddress(roAddress.locality)
-                            @formatAddress(roAddress.region.fold[String]("")(s => s ))
-                            @formatAddress(roAddress.postal_code.fold[String]("")(s => s ))
-                            @formatAddress(roAddress.country)
-                        </td>
-                        <td class="change">
-                            <a href='@controllers.reg.routes.SummaryController.summaryBackLink("company_address")' id="change-roaddress">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.ROAddress.change")</span></a>
-                        </td>
-                    </tr>
+                <tr>
+                    <td class="question">@Messages("page.reg.summary.jurisdictionText")</td>
+                    <td id="jurisdiction" class="answer">@jurisdiction</td>
+                    <td class="change">
+                        <a href='@controllers.reg.routes.SummaryController.summaryBackLink("company_jurisdiction")' id="change-jurisdiction">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.jurisdiction.change")</span></a>
+                    </td>
+                </tr>
 
-                    <tr>
-                        <td class="question">@Messages("page.reg.summary.jurisdictionText")</td>
-                        <td id="jurisdiction" class="answer">@jurisdiction</td>
-                        <td class="change">
-                            <a href='@controllers.reg.routes.SummaryController.summaryBackLink("company_jurisdiction")' id="change-jurisdiction">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.jurisdiction.change")</span></a>
-                        </td>
-                    </tr>
+                <tr>
+                    <td class="question">@Messages("page.reg.summary.PPOBAddressText")</td>
 
-                    <tr>
-                        <td class="question">@Messages("page.reg.summary.PPOBAddressText")</td>
+                    <td id="PPOBAddress" class="answer">
+                        @{
+                        if(ppob.ppob.addressType == "RO"){
+                        ppobMessage
+                        } else {
+                        Html(
+                        ppob.ppob.address.get.addressLine1 + "<br>" +
+                        ppob.ppob.address.get.addressLine2 + "<br>" +
+                        ppob.ppob.address.get.addressLine3.fold[String]("")(s => s + "<br>") +
+                        ppob.ppob.address.get.addressLine4.fold[String]("")(s => s + "<br>") +
+                        ppob.ppob.address.get.postCode.fold[String]("")(s => s + "<br>") +
+                        ppob.ppob.address.get.country.fold[String]("")(s => s )
+                        )
+                        }
+                        }
+                    </td>
+                    <td class="change"><a href="principal-place-of-business" id="change-ppob">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.PPOBAddress.change")</span></a></td>
+                </tr>
+            </tbody>
+        </table>
 
-                        <td id="PPOBAddress" class="answer">
-                            @{
-                            if(ppob.ppob.addressType == "RO"){
-                            ppobMessage
-                            } else {
-                            Html(
-                            ppob.ppob.address.get.addressLine1 + "<br>" +
-                            ppob.ppob.address.get.addressLine2 + "<br>" +
-                            ppob.ppob.address.get.addressLine3.fold[String]("")(s => s + "<br>") +
-                            ppob.ppob.address.get.addressLine4.fold[String]("")(s => s + "<br>") +
-                            ppob.ppob.address.get.postCode.fold[String]("")(s => s + "<br>") +
-                            ppob.ppob.address.get.country.fold[String]("")(s => s )
-                            )
-                            }
-                            }
-                        </td>
-                        <td class="change"><a href="principal-place-of-business" id="change-ppob">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.PPOBAddress.change")</span></a></td>
-                    </tr>
-                </tbody>
-            </table>
+        <table class="check-your-answers multiple-sections">
+            <caption id="companyContactDetails" class="heading-medium">@Messages("page.reg.summary.heading.one.b")</caption>
+            <thead class="visuallyhidden">
+                <tr>
+                    <th>@Messages("page.reg.summary.header.question")</th>
+                    <th>@Messages("page.reg.summary.header.answer")</th>
+                    <th>@Messages("page.reg.summary.header.change")</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="question">@Messages("page.reg.summary.companyContactName")</td>
+                    <td id="companyContactName" class="answer">@ctContactDets.contactName</td>
+                    <td class="change"><a href="company-contact-details" id="change-contact-details">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.companyContactName.change")</span></a></td>
+                </tr>
+                <tr>
+                    <td class="question">@Messages("page.reg.summary.companyContactEmail")</td>
+                    <td id="companyContactEmail" class="answer">@ctContactDets.contactEmail</td>
+                    <td class="change"><a href="company-contact-details" id="change-contact-details-email">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.companyContactEmail.change")</span></a></td>
+                </tr>
+                <tr>
+                    <td class="question">@Messages("page.reg.summary.companyContactDaytimeTelephoneNumber")</td>
+                    <td id="companyContactDaytimeTelephoneNumber" class="answer">@ctContactDets.contactDaytimeTelephoneNumber</td>
+                    <td class="change"><a href="company-contact-details" id="change-contact-details-phoneNumber">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.companyContactDaytimeTelephoneNumber.change")</span></a></td>
+                </tr>
+                <tr>
+                    <td class="question">@Messages("page.reg.summary.companycontactMobileNumber")</td>
+                    <td id="companycontactMobileNumber" class="answer">@ctContactDets.contactMobileNumber</td>
+                    <td class="change"><a href="company-contact-details" id="change-contact-details-mobileNumber">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.companycontactMobileNumber.change")</span></a></td>
+                </tr>
+            </tbody>
+        </table>
 
-            <table class="check-your-answers multiple-sections">
-                <caption id="companyContactDetails" class="heading-medium">@Messages("page.reg.summary.heading.one.b")</caption>
-                <thead class="visuallyhidden">
-                    <tr>
-                        <th>@Messages("page.reg.summary.header.question")</th>
-                        <th>@Messages("page.reg.summary.header.answer")</th>
-                        <th>@Messages("page.reg.summary.header.change")</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td class="question">@Messages("page.reg.summary.companyContactName")</td>
-                        <td id="companyContactName" class="answer">@ctContactDets.contactName</td>
-                        <td class="change"><a href="company-contact-details" id="change-contact-details">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.companyContactName.change")</span></a></td>
-                    </tr>
-                    <tr>
-                        <td class="question">@Messages("page.reg.summary.companyContactEmail")</td>
-                        <td id="companyContactEmail" class="answer">@ctContactDets.contactEmail</td>
-                        <td class="change"><a href="company-contact-details" id="change-contact-details-email">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.companyContactEmail.change")</span></a></td>
-                    </tr>
-                    <tr>
-                        <td class="question">@Messages("page.reg.summary.companyContactDaytimeTelephoneNumber")</td>
-                        <td id="companyContactDaytimeTelephoneNumber" class="answer">@ctContactDets.contactDaytimeTelephoneNumber</td>
-                        <td class="change"><a href="company-contact-details" id="change-contact-details-phoneNumber">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.companyContactDaytimeTelephoneNumber.change")</span></a></td>
-                    </tr>
-                    <tr>
-                        <td class="question">@Messages("page.reg.summary.companycontactMobileNumber")</td>
-                        <td id="companycontactMobileNumber" class="answer">@ctContactDets.contactMobileNumber</td>
-                        <td class="change"><a href="company-contact-details" id="change-contact-details-mobileNumber">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.companycontactMobileNumber.change")</span></a></td>
-                    </tr>
-                </tbody>
-            </table>
+        <table class="check-your-answers multiple-sections">
+            <caption id="companyAccountingTitle" class="heading-medium">@Messages("page.reg.summary.heading.two")</caption>
+            <thead class="visuallyhidden">
+                <tr>
+                    <th>@Messages("page.reg.summary.header.question")</th>
+                    <th>@Messages("page.reg.summary.header.answer")</th>
+                    <th>@Messages("page.reg.summary.header.change")</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="question">@Messages("page.reg.summary.startDate")</td>
+                    <td id="startDate" class="answer">@{if(accDate.crnDate == WHEN_REGISTERED){Messages("page.reg.summary.dateRegistered")}
+                        else if(accDate.crnDate == NOT_PLANNING_TO_YET){Messages("page.reg.summary.notPlanningToStartYet")}
+                        else {accDate.toSummaryDate}}</td>
+                    <td class="change"><a href="accounting-dates" id="change-accountingdates">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.startDate.change")</span></a></td>
+                </tr>
+                <tr>
+                    <td class="question">@Messages("page.reg.summary.tradingDetails")</td>
+                    <td id="tradingDetails" class="answer">@readableTrading(tradingDetails)</td>
+                    <td class="change"><a href="trading-details" id="change-trading-details">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.tradingDetails.change")</span></a></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
-            <table class="check-your-answers multiple-sections">
-                <caption id="companyAccountingTitle" class="heading-medium">@Messages("page.reg.summary.heading.two")</caption>
-                <thead class="visuallyhidden">
-                    <tr>
-                        <th>@Messages("page.reg.summary.header.question")</th>
-                        <th>@Messages("page.reg.summary.header.answer")</th>
-                        <th>@Messages("page.reg.summary.header.change")</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td class="question">@Messages("page.reg.summary.startDate")</td>
-                        <td id="startDate" class="answer">@{if(accDate.crnDate == WHEN_REGISTERED){Messages("page.reg.summary.dateRegistered")}
-                            else if(accDate.crnDate == NOT_PLANNING_TO_YET){Messages("page.reg.summary.notPlanningToStartYet")}
-                            else {accDate.toSummaryDate}}</td>
-                        <td class="change"><a href="accounting-dates" id="change-accountingdates">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.startDate.change")</span></a></td>
-                    </tr>
-                    <tr>
-                        <td class="question">@Messages("page.reg.summary.tradingDetails")</td>
-                        <td id="tradingDetails" class="answer">@readableTrading(tradingDetails)</td>
-                        <td class="change"><a href="trading-details" id="change-trading-details">@Messages("change")<span class="visuallyhidden">@Messages("page.reg.summary.tradingDetails.change")</span></a></td>
-                    </tr>
-                </tbody>
-            </table>
-
-            <br />
-            <div class="form-group">
-                <p>@Messages("page.reg.summary.pleaseReview")</p>
-                <div class="indent">
-                    <p>@messages("page.reg.summary.information.indent")</p>
-                </div>
-            </div>
-            @form(action = controllers.reg.routes.SummaryController.submit()) {
-            <div class="form-group">
-                <button class="button" type="submit" id="next">@Messages("common.button.ConfirmAndContinue")</button>
-            </div>
-            }
+    <div class="form-group">
+        <p>@Messages("page.reg.summary.pleaseReview")</p>
+        <div class="indent">
+            <p>@messages("page.reg.summary.information.indent")</p>
         </div>
     </div>
+    @form(action = controllers.reg.routes.SummaryController.submit()) {
+    <div class="form-group">
+        <button class="button" type="submit" id="next">@Messages("common.button.ConfirmAndContinue")</button>
+    </div>
+    }
 }
 

--- a/app/views/reg/TradingDetailsView.scala.html
+++ b/app/views/reg/TradingDetailsView.scala.html
@@ -55,21 +55,21 @@
         </div>
     </details>
     @form(action = controllers.reg.routes.TradingDetailsController.submit()) {
+        <div class="form-group">
+            @inputRadioGroup(
+                tradingDetails("regularPayments"),
+                Seq(("true",Messages("page.reg.ct61.radioYesLabel")),("false",Messages("page.reg.ct61.radioNoLabel"))),
+                '_fieldsetId -> "regular-payments",
+                '_groupClass -> "inline",
+                '_labelClass -> "block-label radio-label",
+                '_legend -> "Do you expect to make or receive payments?",
+                '_legend -> Messages("page.reg.ct61.heading"),
+                '_legendClass -> "visuallyhidden"
+            )
+        </div>
 
-    @inputRadioGroup(
-        tradingDetails("regularPayments"),
-        Seq(("true",Messages("page.reg.ct61.radioYesLabel")),("false",Messages("page.reg.ct61.radioNoLabel"))),
-        '_fieldsetId -> "regular-payments",
-        '_groupClass -> "form-group inline",
-        '_labelClass -> "block-label radio-label",
-        '_legend -> "Do you expect to make or receive payments?",
-        '_legend -> Messages("page.reg.ct61.heading"),
-        '_legendClass -> "visuallyhidden"
-
-    )
-
-    <div class="form-group">
-        <button class="button" type="submit" id="next">@Messages("common.button.save")</button>
-    </div>
+        <div class="form-group">
+            <button class="button" type="submit" id="next">@Messages("common.button.save")</button>
+        </div>
     }
 }

--- a/app/views/reg/TradingDetailsView.scala.html
+++ b/app/views/reg/TradingDetailsView.scala.html
@@ -9,72 +9,67 @@
 
 @main_template(title = Messages("page.reg.ct61.title"), mainClass = None){
 
-<a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
+    <a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
 
-<div class="grid-row">
     @errorSummary(
     Messages("common.errorSummary.label"),
     tradingDetails
     )
 
-    <div class="column-two-thirds">
+    <header class="page-header">
+        <h1 id="main-heading" class="heading-xlarge">@Messages("page.reg.ct61.heading")</h1>
+    </header>
 
-        <header class="page-header">
-            <h1 id="main-heading" class="heading-xlarge">@Messages("page.reg.ct61.heading")</h1>
-        </header>
+    <div class="form-group">
+        <p class="lede">@Messages("page.reg.ct61.lede")</p>
+    </div>
 
-        <div class="form-group">
-            <p class="lede">@Messages("page.reg.ct61.lede")</p>
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@Messages("page.reg.ct61.bullet1")</li>
+            <li>@Messages("page.reg.ct61.bullet2")</li>
+            <li>@Messages("page.reg.ct61.bullet3")</li>
+        </ul>
+    </div>
+    <details>
+        <summary class="summary">@Messages("page.reg.ct61.whyAsked")</summary>
+        <div class="panel-indent panel-indent--gutter">
+            <p>@Messages("page.reg.ct61.p1")</p>
+            <p>@Messages("page.reg.ct61.p2")</p>
+            <p>@Messages("page.reg.ct61.p3")</p>
         </div>
-
-        <div class="form-group">
+    </details>
+    <details>
+        <summary class="summary">@Messages("page.reg.ct61.directorsLoan")</summary>
+        <div class="panel-indent panel-indent--gutter">
+            <p>@Messages("page.reg.ct61.dL.p1")</p>
             <ul class="list list-bullet">
-                <li>@Messages("page.reg.ct61.bullet1")</li>
-                <li>@Messages("page.reg.ct61.bullet2")</li>
-                <li>@Messages("page.reg.ct61.bullet3")</li>
+                <li>@Messages("page.reg.ct61.dL.bullet1")</li>
+                <li>@Messages("page.reg.ct61.dL.bullet2")</li>
+            </ul>
+            <p>@Messages("page.reg.ct61.dL.p2")</p>
+            <ul class="list list-bullet">
+                <li>@Messages("page.reg.ct61.dL.bullet3")</li>
+                <li>@Messages("page.reg.ct61.dL.bullet4")</li>
             </ul>
         </div>
-        <details>
-            <summary class="summary">@Messages("page.reg.ct61.whyAsked")</summary>
-            <div class="panel-indent panel-indent--gutter">
-                <p>@Messages("page.reg.ct61.p1")</p>
-                <p>@Messages("page.reg.ct61.p2")</p>
-                <p>@Messages("page.reg.ct61.p3")</p>
-            </div>
-        </details>
-        <details>
-            <summary class="summary">@Messages("page.reg.ct61.directorsLoan")</summary>
-            <div class="panel-indent panel-indent--gutter">
-                <p>@Messages("page.reg.ct61.dL.p1")</p>
-                <ul class="list list-bullet">
-                    <li>@Messages("page.reg.ct61.dL.bullet1")</li>
-                    <li>@Messages("page.reg.ct61.dL.bullet2")</li>
-                </ul>
-                <p>@Messages("page.reg.ct61.dL.p2")</p>
-                <ul class="list list-bullet">
-                    <li>@Messages("page.reg.ct61.dL.bullet3")</li>
-                    <li>@Messages("page.reg.ct61.dL.bullet4")</li>
-                </ul>
-            </div>
-        </details>
-        @form(action = controllers.reg.routes.TradingDetailsController.submit()) {
+    </details>
+    @form(action = controllers.reg.routes.TradingDetailsController.submit()) {
 
-        @inputRadioGroup(
-            tradingDetails("regularPayments"),
-            Seq(("true",Messages("page.reg.ct61.radioYesLabel")),("false",Messages("page.reg.ct61.radioNoLabel"))),
-            '_fieldsetId -> "regular-payments",
-            '_groupClass -> "form-group inline",
-            '_labelClass -> "block-label radio-label",
-            '_legend -> "Do you expect to make or receive payments?",
-            '_legend -> Messages("page.reg.ct61.heading"),
-            '_legendClass -> "visuallyhidden"
+    @inputRadioGroup(
+        tradingDetails("regularPayments"),
+        Seq(("true",Messages("page.reg.ct61.radioYesLabel")),("false",Messages("page.reg.ct61.radioNoLabel"))),
+        '_fieldsetId -> "regular-payments",
+        '_groupClass -> "form-group inline",
+        '_labelClass -> "block-label radio-label",
+        '_legend -> "Do you expect to make or receive payments?",
+        '_legend -> Messages("page.reg.ct61.heading"),
+        '_legendClass -> "visuallyhidden"
 
-        )
+    )
 
-        <div class="form-group">
-            <button class="button" type="submit" id="next">@Messages("common.button.save")</button>
-        </div>
-        }
+    <div class="form-group">
+        <button class="button" type="submit" id="next">@Messages("common.button.save")</button>
     </div>
-</div>
+    }
 }

--- a/app/views/reg/Welcome.scala.html
+++ b/app/views/reg/Welcome.scala.html
@@ -6,45 +6,39 @@
 
     <a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
 
-    <div class="grid-row">
-        <div class="column-one-third">
-            <header class="page-header">
-                <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.welcome.heading")</h1>
-            </header>
-            <div class="form-group">
-                <h2 class="heading-medium" id="description-one">@Messages("page.reg.welcome.description.one")</h2>
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.reg.welcome.heading")</h1>
+    </header>
+    <div class="form-group">
+        <h2 class="heading-medium" id="description-one">@Messages("page.reg.welcome.description.one")</h2>
 
-                @{if (PAYESwitch) {
-                <ul class="list list-bullet">
-                    <li id="inc_ct">{Messages("page.reg.welcome.bullet.inc_ct")}</li>
-                    <li id="paye">{Messages("page.reg.welcome.bullet.paye")}</li>
-                </ul>
-                } else
-                {
-                <ul class="list list-bullet">
-                    <li id="inc">{Messages("page.reg.welcome.bullet.inc")}</li>
-                    <li id="ct">{Messages("page.reg.welcome.bullet.ct")}</li>
-                </ul>
-                }
-                }
-            </div>
-            <div class="form-group">
-                <h3 class="heading-medium" id="subheading">@Messages("page.reg.welcome.heading.beforeyoubegin")</h3>
-                <p id="cost">@Messages("page.reg.welcome.cost")</p>
-                <p id="app">@Messages("page.reg.welcome.yourapp")</p>
-                <ul class="list list-bullet">
-                    <li id="30">@Messages("page.reg.welcome.bullet.30-mins")</li>
-                    <li id="one">@Messages("page.reg.welcome.bullet.one-go")</li>
-                    <li id="90">@Messages("page.reg.welcome.bullet.90-days")</li>
-                </ul>
-                @form(action = controllers.reg.routes.WelcomeController.submit()) {
-                <div class="form-group">
-                    <button class="button button--get-started" role="button" id="next">@Messages("common.button.start")</button>
-                </div>
-                }
-            </div>
-
+        @{if (PAYESwitch) {
+        <ul class="list list-bullet">
+            <li id="inc_ct">{Messages("page.reg.welcome.bullet.inc_ct")}</li>
+            <li id="paye">{Messages("page.reg.welcome.bullet.paye")}</li>
+        </ul>
+        } else
+        {
+        <ul class="list list-bullet">
+            <li id="inc">{Messages("page.reg.welcome.bullet.inc")}</li>
+            <li id="ct">{Messages("page.reg.welcome.bullet.ct")}</li>
+        </ul>
+        }
+        }
+    </div>
+    <div class="form-group">
+        <h3 class="heading-medium" id="subheading">@Messages("page.reg.welcome.heading.beforeyoubegin")</h3>
+        <p id="cost">@Messages("page.reg.welcome.cost")</p>
+        <p id="app">@Messages("page.reg.welcome.yourapp")</p>
+        <ul class="list list-bullet">
+            <li id="30">@Messages("page.reg.welcome.bullet.30-mins")</li>
+            <li id="one">@Messages("page.reg.welcome.bullet.one-go")</li>
+            <li id="90">@Messages("page.reg.welcome.bullet.90-days")</li>
+        </ul>
+        @form(action = controllers.reg.routes.WelcomeController.submit()) {
+        <div class="form-group">
+            <button class="button button--get-started" role="button" id="next">@Messages("common.button.start")</button>
         </div>
-
+        }
     </div>
 }

--- a/app/views/verification/verifyYourEmail.scala.html
+++ b/app/views/verification/verifyYourEmail.scala.html
@@ -6,22 +6,17 @@
 
 <a id="back" class="link-back" href="javascript:history.back()">@Messages("common.button.back")</a>
 
-<div class="grid-row">
-    <div class="column-one-third">
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.verification.verify-your-email.title")</h1>
-        </header>
+<header class="page-header">
+    <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.verification.verify-your-email.title")</h1>
+</header>
 
-        <div class="form-group">
-            <p id="description-one">@Messages("page.verification.verify-your-email.description.one") @email@Messages("page.verification.verify-your-email.description.two")</p>
-            <p id="paragraph2">@Messages("page.verification.verify-your-email.paragraph2")</p>
-        </div>
-
-        <details>
-            <summary class="summary">@Messages("page.verification.verify-your-email.dropdown-title")</summary>
-            <p class="panel-indent panel-indent--gutter">@Messages("page.verification.verify-your-email.dropdown-text1") <a href="@controllers.verification.routes.EmailVerificationController.startAgain">@Messages("page.verification.verify-your-email.dropdown-link2")</a>@Messages("page.verification.verify-your-email.dropdown-textend") @Messages("page.verification.verify-your-email.dropdown-text2") <a href="@controllers.reg.routes.SignInOutController.postSignIn(Some(true))"> @Messages("page.verification.verify-your-email.dropdown-link")</a>@Messages("page.verification.verify-your-email.dropdown-textend")</p>
-        </details>
-    </div>
-
+<div class="form-group">
+    <p id="description-one">@Messages("page.verification.verify-your-email.description.one") @email@Messages("page.verification.verify-your-email.description.two")</p>
+    <p id="paragraph2">@Messages("page.verification.verify-your-email.paragraph2")</p>
 </div>
+
+<details>
+    <summary class="summary">@Messages("page.verification.verify-your-email.dropdown-title")</summary>
+    <p class="panel-indent panel-indent--gutter">@Messages("page.verification.verify-your-email.dropdown-text1") <a href="@controllers.verification.routes.EmailVerificationController.startAgain">@Messages("page.verification.verify-your-email.dropdown-link2")</a>@Messages("page.verification.verify-your-email.dropdown-textend") @Messages("page.verification.verify-your-email.dropdown-text2") <a href="@controllers.reg.routes.SignInOutController.postSignIn(Some(true))"> @Messages("page.verification.verify-your-email.dropdown-link")</a>@Messages("page.verification.verify-your-email.dropdown-textend")</p>
+</details>
 }


### PR DESCRIPTION
While going to bump AF versions I was faced with broken layouts when running and testing locally.

### The problem
We use the HMRC template, which has a content wrapper with .content__body class. That class has a width of 61.666667%. Within that, in our own app, we have 2 further content wrapper divs - .grid-row and in side that .column-one third or .column-two-thirds. These wrapper divs currently do nothing. For some unknown reason those classes on those divs aren't picking up the the intended styles. But all of a sudden locally when running the app they are and are breaking layout (see before and after screenshots below for example).

.grid-row is designed to display rows of content (columns) side by side and the .column-(width-size) divs define the width of the column of content. For example .column-one-third should be 33.3333% in width and .column-two-thirds should be 66.6666% wide and so on. These column width classes come packaged with 15 pixels padding left and right, so when sat side by side this gives a 30 pixel gutter. The .grid-row class has a -15 pixel left and right margins to offset the 15 pixels padding so that the .grid-row column content aligns with the rest of the page content.

### The solution
While we are using the HMRC template and template styles that have the .content__body class which provides the content width limitations described above. We simply do not need 2 further content wrapper divs with classes that (when picking up correct styles) break layout. So I have simply removed these these wrapper divs and classes.

## Screenshots showing before and after
![column-before-after](https://user-images.githubusercontent.com/1692222/31336283-0aff234e-acee-11e7-8374-92049a107f43.jpg)

### Additional work included in pull request
- general markup tidy, tidying markup as I go when noticing inconsistencies
- replacing .form-group classes where necessary to replace <br>'s for improved tidier markup and more consistent vertical spacing between elements. This also conforms better with GOV.UK markup recommendations and examples.
- updating markup indents to improve scan-ability and read-ability of code and consistency