### PR TITLE
Bump HMRC AF to version 2.251.1

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -31,7 +31,7 @@ application.langs="en,cy"
 play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 www.google-analytics.com data:"
 
 assets {
-  version = "2.249.0"
+  version = "2.251.1"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
 }


### PR DESCRIPTION
This bump includes:
• minor updates to padding of continue buttons
• updates to border thickness of text inputs
Both update styles for consistency

### Before
<img width="201" alt="screen shot 2017-10-09 at 13 08 37" src="https://user-images.githubusercontent.com/1692222/31337503-8894282c-acf3-11e7-9160-d28dd850020b.png">
<img width="463" alt="screen shot 2017-10-09 at 13 08 55" src="https://user-images.githubusercontent.com/1692222/31337507-8e5805b2-acf3-11e7-8370-23af50f8a492.png">

### After
<img width="208" alt="screen shot 2017-10-09 at 13 11 45" src="https://user-images.githubusercontent.com/1692222/31337523-9b6de69a-acf3-11e7-973b-1920a683fd94.png">
<img width="477" alt="screen shot 2017-10-09 at 13 11 36" src="https://user-images.githubusercontent.com/1692222/31337530-a24fff84-acf3-11e7-890d-a40ade803d31.png">


