### PR TITLE
Update continue and Start now button markup to conform to GOV.UK standards

### DIFF
--- a/app/views/errors/submissionFailed.scala.html
+++ b/app/views/errors/submissionFailed.scala.html
@@ -47,7 +47,7 @@
     )
 </fieldset>
 
-<button class="button" type="submit" id="continue" >@Messages("errorPages.failedSubmission.button")</button>
+<input class="button" type="submit" id="continue" name="action" value="@Messages("errorPages.failedSubmission.button")">
 }
 
 }

--- a/app/views/errors/submissionTimeout.scala.html
+++ b/app/views/errors/submissionTimeout.scala.html
@@ -11,7 +11,7 @@
 <p class="spaced-below">@Messages("errorPages.retrySubmission.p2")</p>
 
 @govHelpers.form(action = controllers.handoff.routes.BasicCompanyDetailsController.basicCompanyDetails) {
-<button class="button" type="submit" id="continue" >@Messages("errorPages.retrySubmission.button")</button>
+<input class="button" type="submit" id="continue" name="action" value="@Messages("errorPages.retrySubmission.button")">
 }
 
 }

--- a/app/views/reg/AccountingDates.scala.html
+++ b/app/views/reg/AccountingDates.scala.html
@@ -60,7 +60,7 @@
         </div>
 
         <div class="form-group">
-            <button class="btn button" id="next">@Messages("common.button.snc")</button>
+            <input class="button" type="submit" id="next" value="@Messages("common.button.snc")">
         </div>
     }
 }

--- a/app/views/reg/CancelPaye.scala.html
+++ b/app/views/reg/CancelPaye.scala.html
@@ -33,7 +33,7 @@
         </div>
 
         <div class="form-group">
-            <button class="button" type="submit" id="next">@Messages("common.button.save")</button>
+            <input class="button" type="submit" id="next" value="@Messages("common.button.save")">
         </div>
     }
 }

--- a/app/views/reg/CompanyContactDetails.scala.html
+++ b/app/views/reg/CompanyContactDetails.scala.html
@@ -65,7 +65,7 @@
         </fieldset>
 
         <div class="form-group">
-            <button class="btn button" id="next">@Messages("common.button.snc")</button>
+            <input class="button" type="submit" id="next" value="@Messages("common.button.snc")">
         </div>
     }
 

--- a/app/views/reg/CompletionCapacity.scala.html
+++ b/app/views/reg/CompletionCapacity.scala.html
@@ -47,7 +47,7 @@
         </div>
 
         <div class="form-group">
-            <button class="btn button" id="next">@Messages("common.button.snc")</button>
+            <input class="button" type="submit" id="next" value="@Messages("common.button.snc")">
         </div>
     }
 }

--- a/app/views/reg/Confirmation.scala.html
+++ b/app/views/reg/Confirmation.scala.html
@@ -34,9 +34,9 @@
 
     <br>
     @form(action = controllers.reg.routes.ConfirmationControllerImpl.submit()) {
-    <div class="form-group">
-        <button class="btn button" role="button" id="next">@Messages("page.reg.finish.btn")</button>
-    </div>
+        <div class="form-group">
+            <input class="button" type="submit" id="next" value="@Messages("page.reg.finish.btn")">
+        </div>
     }
     <div class="form-group">
         <a href="questionnaire">@Messages("page.reg.Confirmation.questionnaire.link")</a>

--- a/app/views/reg/IncompleteRegistration.scala.html
+++ b/app/views/reg/IncompleteRegistration.scala.html
@@ -20,9 +20,8 @@
 
         <p id="description-two">@Messages("page.reg.incompleteReg.description.two")</p>
     </div>
-    @form(action = controllers.reg.routes.IncompleteRegistrationController.submit()) {
+
     <div class="form-group">
-        <button class="button-get-started" role="button" id="next">@Messages("common.button.sign-in")</button>
+        <a class="button--get-started" href="@controllers.reg.routes.CompletionCapacityController.show()" role="button" id="next">@Messages("common.button.sign-in")</a>
     </div>
-    }
 }

--- a/app/views/reg/PrinciplePlaceOfBusiness.scala.html
+++ b/app/views/reg/PrinciplePlaceOfBusiness.scala.html
@@ -38,7 +38,7 @@
         </div>
 
         <div class="form-group" id="nextButton">
-            <button class="btn button" id="next" name="action" value="continue">@Messages("common.button.snc")</button>
+            <input class="button" type="submit" id="next" name="action" value="@Messages("common.button.snc")">
         </div>
     }
 }

--- a/app/views/reg/Questionnaire.scala.html
+++ b/app/views/reg/Questionnaire.scala.html
@@ -106,7 +106,7 @@
         <textarea cols="30" rows="4" class="form-control textarea--fullwidth" id="improvementsTb" name="improvements">@qForm("improvements").value</textarea>
     </div>
     <div class="form-group">
-        <button class="button" role="button" id="next">@Messages("page.reg.questionnaire.send")</button>
+        <input class="button" type="submit" id="next" value="@Messages("page.reg.questionnaire.send")">
     </div>
     }
 }

--- a/app/views/reg/RegistrationUnsuccessful.scala.html
+++ b/app/views/reg/RegistrationUnsuccessful.scala.html
@@ -26,7 +26,7 @@
             </br>
 
             <div class="form-group">
-                <button class="btn button" id="next">@Messages("common.button.next")</button>
+                <input class="button" type="submit" id="next" value="@Messages("common.button.next")">
             </div>
         }
     </div>

--- a/app/views/reg/ReturningUserView.scala.html
+++ b/app/views/reg/ReturningUserView.scala.html
@@ -33,7 +33,7 @@
     )
 
     <div class="form-group">
-        <button class="button" type="submit" id="next">@Messages("common.button.save")</button>
+        <input class="button" type="submit" id="next" value="@Messages("common.button.save")">
     </div>
     }
 }

--- a/app/views/reg/Summary.scala.html
+++ b/app/views/reg/Summary.scala.html
@@ -193,7 +193,7 @@
     </div>
     @form(action = controllers.reg.routes.SummaryController.submit()) {
     <div class="form-group">
-        <button class="button" type="submit" id="next">@Messages("common.button.ConfirmAndContinue")</button>
+        <input class="button" type="submit" id="next" value="@Messages("common.button.ConfirmAndContinue")">
     </div>
     }
 }

--- a/app/views/reg/TestEndpoint.scala.html
+++ b/app/views/reg/TestEndpoint.scala.html
@@ -166,7 +166,7 @@
         <br>
 
         <div class="form-group">
-            <button class="btn button" id="next">@Messages("common.button.snc")</button>
+            <input class="button" type="submit" id="next" value="@Messages("common.button.snc")">
         </div>
     }
 

--- a/app/views/reg/TradingDetailsView.scala.html
+++ b/app/views/reg/TradingDetailsView.scala.html
@@ -69,7 +69,7 @@
         </div>
 
         <div class="form-group">
-            <button class="button" type="submit" id="next">@Messages("common.button.save")</button>
+            <input class="button" type="submit" id="next" value="@Messages("common.button.save")">
         </div>
     }
 }

--- a/app/views/reg/Welcome.scala.html
+++ b/app/views/reg/Welcome.scala.html
@@ -35,10 +35,9 @@
             <li id="one">@Messages("page.reg.welcome.bullet.one-go")</li>
             <li id="90">@Messages("page.reg.welcome.bullet.90-days")</li>
         </ul>
-        @form(action = controllers.reg.routes.WelcomeController.submit()) {
+
         <div class="form-group">
-            <button class="button button--get-started" role="button" id="next">@Messages("common.button.start")</button>
+            <a class="button button--get-started" href="@controllers.reg.routes.ReturningUserController.show()" role="button" id="next">@Messages("common.button.start")</a>
         </div>
-        }
     </div>
 }

--- a/app/views/test/EMTPPostView.scala.html
+++ b/app/views/test/EMTPPostView.scala.html
@@ -50,7 +50,7 @@
             </div>
 
             <div class="form-group">
-                <button class="btn button" id="next">@Messages("common.button.snc")</button>
+                <input class="button" type="submit" id="next" value="@Messages("common.button.snc")">
             </div>
         }
     </div>

--- a/app/views/test/FeatureSwitch.scala.html
+++ b/app/views/test/FeatureSwitch.scala.html
@@ -31,7 +31,7 @@
             '_groupClass -> "form-group inline"
             )
             <div class="form-group">
-                <button class="button btn" role="button" id="next">Submit</button>
+                <input class="button" type="submit" id="next" value="Submit">
             </div>
         }
     </div>

--- a/app/views/verification/createNewAccount.scala.html
+++ b/app/views/verification/createNewAccount.scala.html
@@ -19,7 +19,7 @@
         </div>
         @form(action = controllers.verification.routes.EmailVerificationController.createSubmit()) {
         <div class="form-group">
-            <button class="button button--link">@Messages("page.verification.create-new-account.bottomLink")</button>
+            <input class="button button--link" type="submit" value="@Messages("page.verification.create-new-account.bottomLink")">
         </div>
         }
     </div>

--- a/test/views/CompanyContactDetailsSpec.scala
+++ b/test/views/CompanyContactDetailsSpec.scala
@@ -64,7 +64,7 @@ class CompanyContactDetailsSpec extends SCRSSpec with CompanyContactDetailsFixtu
           document.getElementById("contactEmailLabel").text() shouldBe "Email address"
           document.getElementById("contactDaytimePhoneLabel").text() shouldBe "Contact number"
           document.getElementById("contactMobileLabel").text() shouldBe "Other contact number"
-          document.getElementById("next").text() shouldBe "Save and continue"
+          document.getElementById("next").attr("value") shouldBe "Save and continue"
           document.getElementById("helpMessage1").text() shouldBe "Provide at least one of the following contact details."
       }
     }

--- a/test/views/PPOBSpec.scala
+++ b/test/views/PPOBSpec.scala
@@ -68,7 +68,7 @@ class PPOBSpec extends SCRSSpec with PPOBFixture with NavModelRepoMock with With
           val document = Jsoup.parse(contentAsString(result))
           document.title() shouldBe "Where will the company carry out most of its business activities?"
           document.getElementById("main-heading").text shouldBe "Where will the company carry out most of its business activities?"
-          document.getElementById("next").text shouldBe "Save and continue"
+          document.getElementById("next").attr("value") shouldBe "Save and continue"
       }
     }
   }


### PR DESCRIPTION
Currently we use
- button instead of input type="submit" for Save and continue buttons (http://govuk-elements.herokuapp.com/buttons/#button-text)
- button instead of anchor links for Start now buttons (http://govuk-elements.herokuapp.com/buttons/#button-start-now)

This commit and PR updates this.

I have also removed .btn class because it's doing nothing and isn't required.

There are no visible changes made to show or demo. Only changes in markup.