### PR TITLE
Updating Get help with this page link to match CH

### DIFF
--- a/public/stylesheets/scrs-styling.css
+++ b/public/stylesheets/scrs-styling.css
@@ -1,5 +1,5 @@
 @import 'form-validation.css';
-@import 'header.css';
+@import 'taas.css';
 
 /* All the styles below can be deleted when HMRC AF moves to version 3 and/or 4 */
 @media (min-width: 641px) {

--- a/public/stylesheets/taas.css
+++ b/public/stylesheets/taas.css
@@ -1,4 +1,8 @@
-/* Global header bar */
+/* This files are local css changes to the CT app, which we will most likely delete when we move to Template as a Service (TAAS) */
+
+
+
+/* ---- Global header bar ---- */
 
 /*
 	This I'm guessing will become redundant if HMRC move to creating TaaS (Template as a Service)
@@ -15,4 +19,22 @@
   max-width: 1020px;
   height: 10px;
   background-color: #005ea5;
+}
+
+
+
+/* ---- Get help with this page link over rides ---- */
+
+.report-error .report-error__toggle {
+	font-size: 16px;
+}
+
+@media (min-width: 641px) {
+	.report-error .report-error__toggle {
+		font-size: 19px;
+	}
+}
+
+.report-error {
+	margin-top: 0;
 }


### PR DESCRIPTION
To match CH styling for Get help with this page link that appears below Start now and continue buttons.

### Screenshots of before and after
![before-after-get-help](https://user-images.githubusercontent.com/1692222/31674130-ec166cb4-b358-11e7-94f1-462e1d994730.jpg)

### Screenshots showing we now match CH
![ch-vs-scrs](https://user-images.githubusercontent.com/1692222/31674146-fee0260a-b358-11e7-9cce-90e11dd898f4.jpg)


I have re-named header.css file to taas.css because this now contains deletable local styles which we can simply remove when Template as a Service (TAAS) come along.