### PR TITLE
Adding print styles to improve print

### DIFF
--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -38,6 +38,7 @@
     <meta name="format-detection" content="telephone=no" />
     <link rel="stylesheet" href="@routes.Assets.at("stylesheets/scrs-styling.css")">
     <link rel="stylesheet" href="@routes.Assets.at("stylesheets/timeout-dialog.css")">
+    <link rel="stylesheet" media="print" type="text/css" href="@routes.Assets.at("stylesheets/scrs-print.css")">
 }
 
 @headerNavLinks = {

--- a/public/stylesheets/scrs-print.css
+++ b/public/stylesheets/scrs-print.css
@@ -1,0 +1,55 @@
+/* Print styles to improve Summary / Check your answers pages */
+
+/* removes padding so the content aligns with the header in print */
+article h1+h2 {
+	margin-bottom: 30px;
+}
+
+.heading-medium {
+	margin: 10px 0 10px;
+}
+
+
+/* Styles for layout using dl */
+
+.govuk-check-your-answers {
+	margin: 0 0 40px; 
+}
+
+.cya-question,
+.cya-answer {
+	display: inline-block;
+	width: 50%;
+	vertical-align: top !important;
+}
+
+.cya-answer {
+	width: 33.33%;
+	padding: 10px 0;
+	margin-bottom: 0;
+}
+
+
+/* template styles */
+#global-header {
+	margin-bottom: 0;
+}
+
+#content {
+	padding: 0;
+}
+
+.cya-change,
+.report-error,
+.button,
+.link-back,
+.phase-banner,
+.header__menu__proposition-links,
+.menu {
+	display: none;
+}
+
+.header__menu__proposition-name {
+	color: #000;
+	font-size: 27px;
+}


### PR DESCRIPTION
This includes print styles for template which improve all pages and specific print styles to vastly improve check your answers pages.

Changes include:
- Removing all unnecessary elements for print i.e. back link, phase banner, continue button, change links, sign out links and so on
- improving clarity of service title
- general page tidy up to improve readability of the printed page

## Before
[summary-page-before.pdf](https://github.com/hmrc/company-registration-frontend/files/1792926/summary-page-before.pdf)

## After
[summary-page-after.pdf](https://github.com/hmrc/company-registration-frontend/files/1792927/summary-page-after.pdf)
