### PR TITLE
SCRS-10898 uplifted frontend-boostrap to 8.19.0

### DIFF
--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -24,7 +24,7 @@ private object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "frontend-bootstrap" % "8.17.0",
+    "uk.gov.hmrc" %% "frontend-bootstrap" % "8.19.0",
     "uk.gov.hmrc" %% "auth-client" % "2.5.0",
     "uk.gov.hmrc" %% "play-partials" % "6.1.0",
     "uk.gov.hmrc" %% "url-builder" % "2.1.0",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14073782/37285448-edea48ce-25f6-11e8-93c9-7339176e7354.png)

play-ui 7.14.0 is transient (as seen in the screenshot)