### PR TITLE
Added signposting feature flag to CRFE

### DIFF
--- a/app/controllers/reg/WelcomeController.scala
+++ b/app/controllers/reg/WelcomeController.scala
@@ -28,9 +28,15 @@ object WelcomeController extends WelcomeController
 trait WelcomeController extends FrontendController with MessagesSupport {
 
   val show = Action.async { implicit request =>
-    Future.successful(Ok(Welcome(SCRSFeatureSwitches.paye.enabled)))
+    if (signPostingEnabled) {
+      Future.successful(PermanentRedirect(routes.SignInOutController.postSignIn(None).url))
+    } else {
+      Future.successful(Ok(Welcome(SCRSFeatureSwitches.paye.enabled)))
+    }
   }
   val submit = Action.async { implicit request =>
     Future.successful(Redirect(routes.ReturningUserController.show()))
   }
+
+  def signPostingEnabled: Boolean = SCRSFeatureSwitches.signPosting.enabled
 }

--- a/app/utils/FeatureSwitch.scala
+++ b/app/utils/FeatureSwitch.scala
@@ -108,6 +108,7 @@ trait SCRSFeatureSwitches {
   def legacyEnv                 = FeatureSwitch.getProperty(LEGACY_ENV)
   def contactUs                 = FeatureSwitch.getProperty("contactUs")
   def systemDate                = FeatureSwitch.getProperty("system-date")
+  def signPosting               = FeatureSwitch.getProperty("signPosting")
 
   def apply(name: String): Option[FeatureSwitch] = name match {
     case COHO                        => Some(cohoFirstHandOff)
@@ -117,6 +118,7 @@ trait SCRSFeatureSwitches {
     case LEGACY_ENV                  => Some(legacyEnv)
     case "contactUs"                 => Some(contactUs)
     case "system-date"               => Some(systemDate)
+    case "signPosting"               => Some(signPosting)
     case _                           => None
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -194,6 +194,11 @@ microservice {
       port = 9970
       url = "http://localhost:9970"
     }
+    company-registration-eligibility-frontend {
+      host = localhost
+      port = 9972
+      url  = "/eligibility-for-setting-up-company"
+    }
     address-lookup{
       host = localhost
       port = 9022

--- a/it/itutil/IntegrationSpecBase.scala
+++ b/it/itutil/IntegrationSpecBase.scala
@@ -29,7 +29,8 @@ trait IntegrationSpecBase extends UnitSpec
   def setupFeatures(cohoFirstHandOff: Boolean = false,
                     businessActivitiesHandOff: Boolean = false,
                     paye: Boolean = false,
-                    vat: Boolean = false) = {
+                    vat: Boolean = false,
+                    signPosting: Boolean = false) = {
     def enableFeature(fs: FeatureSwitch, enabled: Boolean) = {
       enabled match {
         case true => FeatureSwitch.enable(fs)
@@ -40,6 +41,7 @@ trait IntegrationSpecBase extends UnitSpec
     enableFeature(SCRSFeatureSwitches.businessActivitiesHandOff, businessActivitiesHandOff)
     enableFeature(SCRSFeatureSwitches.paye, paye)
     enableFeature(SCRSFeatureSwitches.vat, vat)
+    enableFeature(SCRSFeatureSwitches.signPosting, signPosting)
   }
 
   override def beforeEach() = {

--- a/it/www/ReturningUserControllerISpec.scala
+++ b/it/www/ReturningUserControllerISpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package www
+
+import java.util.UUID
+
+import itutil.{FakeAppConfig, IntegrationSpecBase, LoginStub, WiremockHelper}
+import org.scalatest.BeforeAndAfterEach
+import play.api.http.HeaderNames
+import play.api.libs.ws.WSResponse
+import play.api.test.FakeApplication
+
+import scala.concurrent.Future
+
+class ReturningUserControllerISpec extends IntegrationSpecBase with LoginStub with BeforeAndAfterEach with FakeAppConfig {
+
+  val mockHost = WiremockHelper.wiremockHost
+  val mockPort = WiremockHelper.wiremockPort
+
+  override implicit lazy val app = FakeApplication(additionalConfiguration = fakeConfig())
+
+  private def client(path: String) = ws.url(s"http://localhost:$port/register-your-company$path").withFollowRedirects(false)
+
+  val userId = "/wibble"
+
+  "POST /setting-up-new-limited-company" should {
+    val map = Map(
+      "csrfToken"-> Seq("xxx-ignored-xxx"),
+      "returningUser" -> Seq("true")
+    )
+
+    "redirect when starting a new registration to creating a new account if the signposting is disabled" in {
+      val csrfToken = UUID.randomUUID().toString
+      val sessionCookie = getSessionCookie(Map("csrfToken" -> csrfToken), userId)
+
+      setupFeatures()
+
+      val post: Future[WSResponse] = client("/setting-up-new-limited-company")
+        .withHeaders(HeaderNames.COOKIE -> sessionCookie, "Csrf-Token" -> "nocheck")
+        .post(map)
+      val response = await(post)
+
+      response.status shouldBe 303
+
+      val redirectTo = response.header(HeaderNames.LOCATION)
+
+      redirectTo shouldBe defined
+      redirectTo map { r =>
+        r should include("/government-gateway-registration-frontend")
+        r should include("origin=company-registration-frontend")
+        r should include("register-your-company%2Fpost-sign-in")
+      }
+    }
+
+    "redirect when starting a new registration to company registration eligibility frontend if the signposting enabled" in {
+      val csrfToken = UUID.randomUUID().toString
+      val sessionCookie = getSessionCookie(Map("csrfToken" -> csrfToken), userId)
+
+      setupFeatures(signPosting = true)
+
+      val post: Future[WSResponse] = client("/setting-up-new-limited-company")
+        .withHeaders(HeaderNames.COOKIE -> sessionCookie, "Csrf-Token" -> "nocheck")
+        .post(map)
+      val response = await(post)
+
+      response.status shouldBe 303
+
+      val redirectTo = response.header(HeaderNames.LOCATION)
+
+      redirectTo shouldBe defined
+      redirectTo map { r =>
+        r should include("/eligibility-for-setting-up-company")
+      }
+    }
+  }
+}

--- a/test/connectors/EmailVerificationConnectorSpec.scala
+++ b/test/connectors/EmailVerificationConnectorSpec.scala
@@ -22,19 +22,14 @@ import org.mockito.Matchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
 import org.scalatest.mockito.MockitoSugar
-
-import scala.concurrent.ExecutionContext
-//import org.scalatestplus.play.OneServerPerSuite
 import play.api.http.Status._
 import play.api.libs.json.JsValue
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class EmailVerificationConnectorSpec extends SCRSSpec with UnitSpec with WithFakeApplication with MockitoSugar with BeforeAndAfter {
-
-  val mockEmailVerificationConnector = mock[EmailVerificationConnector]
 
 
   trait Setup {

--- a/test/controllers/CompletionCapacityControllerSpec.scala
+++ b/test/controllers/CompletionCapacityControllerSpec.scala
@@ -37,7 +37,6 @@ import scala.concurrent.Future
 class CompletionCapacityControllerSpec extends SCRSSpec with WithFakeApplication with MockitoSugar with BusinessRegistrationFixture with AuthBuilder {
 
   val mockBusinessRegConnector = mock[BusinessRegistrationConnector]
-  val mockMetaDataService = mock[MetaDataService]
 
 
   class Setup {

--- a/test/controllers/ReturningUserSpec.scala
+++ b/test/controllers/ReturningUserSpec.scala
@@ -28,9 +28,10 @@ class ReturningUserSpec extends SCRSSpec with AuthBuilder with WithFakeApplicati
   class Setup {
     object TestController extends ReturningUserController{
       val createGGWAccountUrl = "CreateGGWAccountURL"
-      val compRegFeUrl = "CompRegFEURL"
-      val authConnector = mockAuthConnector
-
+      val eligUri             = "/check-if-you-can-setup-a-company"
+      val eligUrl             = "EligURL"
+      val compRegFeUrl        = "CompRegFEURL"
+      val authConnector       = mockAuthConnector
     }
   }
 
@@ -57,6 +58,13 @@ class ReturningUserSpec extends SCRSSpec with AuthBuilder with WithFakeApplicati
         status(result) shouldBe SEE_OTHER
         redirectLocation(result).get should include("CreateGGWAccountURL/government-gateway-registration-frontend")
         redirectLocation(result).get should include("continue=CompRegFEURL%2Fregister-your-company%2Fpost-sign-in")
+      }
+      "return a 303 and send user to company registration eligibility when they start a new registration with signposting" in new Setup {
+        System.setProperty("feature.signPosting", "true")
+
+        val result = TestController.submit()(FakeRequest().withFormUrlEncodedBody("returningUser" -> "true"))
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result).get should include("EligURL")
       }
       "return a 303 and send user to sign-in page when they are not starting a new registration" in new Setup {
 

--- a/test/controllers/SignInOutControllerSpec.scala
+++ b/test/controllers/SignInOutControllerSpec.scala
@@ -42,7 +42,6 @@ class SignInOutControllerSpec extends SCRSSpec
   with UserDetailsFixture with PayloadFixture with PPOBFixture with BusinessRegistrationFixture with CompanyDetailsFixture with WithFakeApplication
   with AuthBuilder {
 
-  val mockEmailService = mock[EmailVerificationService]
   val mockEnrolmentsService = mock[EnrolmentsService]
 
 
@@ -96,7 +95,7 @@ class SignInOutControllerSpec extends SCRSSpec
         .thenReturn(Future.successful((Some(true), Some("String"))))
 
       when(mockEmailService.sendWelcomeEmail(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any()))
-        .thenReturn(Future.successful(Some(true)))
+        .thenReturn(Future.successful(Some(false)))
 
       when(mockCompanyRegistrationConnector.fetchRegistrationStatus(Matchers.any())(Matchers.any()))
         .thenReturn(Future.successful(None))
@@ -122,6 +121,12 @@ class SignInOutControllerSpec extends SCRSSpec
 
       when(mockHandOffService.cacheRegistrationID(Matchers.eq(registrationID))(Matchers.any()))
         .thenReturn(Future.successful(cacheMap))
+
+      when(mockEmailService.isVerified(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful((Some(true), Some("String"))))
+
+      when(mockEmailService.sendWelcomeEmail(Matchers.any(), Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any()))
+        .thenReturn(Future.successful(Some(true)))
 
       showWithAuthorisedUserRetrieval(controller.postSignIn(None), authDetails) {
         result =>

--- a/test/controllers/SummaryControllerSpec.scala
+++ b/test/controllers/SummaryControllerSpec.scala
@@ -40,8 +40,6 @@ import scala.concurrent.Future
 class SummaryControllerSpec extends SCRSSpec with SCRSFixtures with WithFakeApplication with AccountingDetailsFixture with TradingDetailsFixtures
   with CorporationTaxFixture with AuthBuilder {
 
-  val mockMetaDataService = mock[MetaDataService]
-
   val aboutYouData = AboutYouChoice("Director")
   val mockNavModelRepoObj = mockNavModelRepo
 

--- a/test/controllers/TestEndpointControllerSpec.scala
+++ b/test/controllers/TestEndpointControllerSpec.scala
@@ -30,7 +30,7 @@ import org.scalatest.mockito.MockitoSugar
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import services.{DashboardService, MetaDataService}
+import services.DashboardService
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
@@ -51,7 +51,6 @@ class TestEndpointControllerSpec extends SCRSSpec with SCRSFixtures with Mockito
   val userIds = UserIDs("testInternal","testExternal")
 
   val mockSCRSFeatureSwitches           = mock[SCRSFeatureSwitches]
-  val mockMetaDataService               = mock[MetaDataService]
   val mockDynamicStubConnector          = mock[DynamicStubConnector]
   val mockBusinessRegistrationConnector = mock[BusinessRegistrationConnector]
   val mockDashboardService              = mock[DashboardService]

--- a/test/controllers/WelcomeControllerSpec.scala
+++ b/test/controllers/WelcomeControllerSpec.scala
@@ -28,10 +28,21 @@ class WelcomeControllerSpec extends SCRSSpec with WithFakeApplication {
   }
 
   "Sending a GET request to WelcomeController" should {
-    "return a 200" in new Setup {
+    "send the user to post-sign-in if signposting is enabled" when {
+      "they show the page" in new Setup {
+        System.setProperty("feature.signPosting", "true")
 
-      val result = TestController.show()(FakeRequest())
-      status(result) shouldBe OK
+        val result = TestController.show()(FakeRequest())
+        status(result) shouldBe PERMANENT_REDIRECT
+      }
+    }
+    "send the user to welcome if signposting is disabled" when {
+      "they show the page" in new Setup {
+        System.setProperty("feature.signPosting", "false")
+
+        val result = TestController.show()(FakeRequest())
+        status(result) shouldBe OK
+      }
     }
   }
 

--- a/test/mocks/SCRSMocks.scala
+++ b/test/mocks/SCRSMocks.scala
@@ -16,7 +16,7 @@
 
 package mocks
 
-import connectors.{IncorpInfoConnector, KeystoreConnector}
+import connectors.{EmailVerificationConnector, IncorpInfoConnector, KeystoreConnector, SendTemplatedEmailConnector}
 import org.mockito.Matchers
 import org.mockito.Matchers.{any, eq => eqTo}
 import org.mockito.Mockito._
@@ -48,7 +48,12 @@ trait SCRSMocks
   lazy val mockAuditConnector = mock[AuditConnector]
   lazy val mockIncorpInfoConnector = mock[IncorpInfoConnector]
   lazy val mockDeleteSubmissionService = mock[DeleteSubmissionService]
+  lazy val mockEmailService = mock[EmailVerificationService]
   lazy val mockPPOBService = mock[PPOBService]
+  lazy val mockCommonService = mock[CommonService]
+  lazy val mockMetaDataService = mock[MetaDataService]
+  lazy val mockEmailVerificationConnector = mock[EmailVerificationConnector]
+  lazy val mockSendTemplateEmailConnector = mock[SendTemplatedEmailConnector]
 
   def mockFetchRegistrationID[T <: CommonService](response: String, mock : T) = {
     when(mock.fetchRegistrationID(Matchers.any[HeaderCarrier]()))
@@ -73,5 +78,9 @@ trait SCRSMocks
     reset(mockCompanyContactDetailsService)
     reset(mockAudit)
     reset(mockNavModelRepo)
+    reset(mockEmailService)
+    reset(mockCommonService)
+    reset(mockEmailVerificationConnector)
+    reset(mockSendTemplateEmailConnector)
   }
 }

--- a/test/services/HandOffServiceSpec.scala
+++ b/test/services/HandOffServiceSpec.scala
@@ -64,8 +64,6 @@ class HandOffServiceSpec extends SCRSSpec with PayloadFixture with CTDataFixture
     System.clearProperty("feature.businessActivitiesHandOff")
   }
 
-  val mockCommonService = mock[CommonService]
-
   val externalID = "testExternalID"
 
   "buildBusinessActivitiesPayload" should {

--- a/test/services/TradingDetailsServiceSpec.scala
+++ b/test/services/TradingDetailsServiceSpec.scala
@@ -32,27 +32,23 @@ import scala.concurrent.Future
 
 class TradingDetailsServiceSpec extends SCRSSpec with SCRSMocks with TradingDetailsFixtures {
 
-  val mockKeyStoreConnector = mock[KeystoreConnector]
-  val mockCompRegConnector = mock[CompanyRegistrationConnector]
-  val mockCommonService = mock[CommonService]
-
   lazy val regID = UUID.randomUUID.toString
 
   class Setup {
     object TestService extends TradingDetailsService {
-      val keystoreConnector = mockKeyStoreConnector
-      val compRegConnector = mockCompRegConnector
+      val keystoreConnector = mockKeystoreConnector
+      val compRegConnector = mockCompanyRegistrationConnector
     }
   }
 
   "Updating the trading details data for a given user" should {
     "return a TradingDetailsSuccessResponse" in new Setup {
-      when(mockKeyStoreConnector.fetchAndGet[String](Matchers.eq("registrationID"))(Matchers.any[HeaderCarrier](), Matchers.any[Format[String]]()))
+      when(mockKeystoreConnector.fetchAndGet[String](Matchers.eq("registrationID"))(Matchers.any[HeaderCarrier](), Matchers.any[Format[String]]()))
         .thenReturn(Future.successful(Some(regID)))
 
       when(mockCommonService.fetchRegistrationID(Matchers.any[HeaderCarrier]())).thenReturn(Future.successful(regID))
 
-      when(mockCompRegConnector.updateTradingDetails(Matchers.eq(regID), Matchers.eq(tradingDetailsTrue))(Matchers.any[HeaderCarrier]()))
+      when(mockCompanyRegistrationConnector.updateTradingDetails(Matchers.eq(regID), Matchers.eq(tradingDetailsTrue))(Matchers.any[HeaderCarrier]()))
         .thenReturn(Future.successful(tradingDetailsSuccessResponseTrue))
 
       val result = TestService.updateCompanyInformation(tradingDetailsTrue)
@@ -67,7 +63,7 @@ class TradingDetailsServiceSpec extends SCRSSpec with SCRSMocks with TradingDeta
 
       mockHttpGet[Option[TradingDetails]]("testUrl", Some(tradingDetailsTrue))
 
-      when(mockCompRegConnector.retrieveTradingDetails(Matchers.eq(regID))(Matchers.any[HeaderCarrier]()))
+      when(mockCompanyRegistrationConnector.retrieveTradingDetails(Matchers.eq(regID))(Matchers.any[HeaderCarrier]()))
         .thenReturn(Future.successful(Some(tradingDetailsTrue)))
 
       val result = TestService.retrieveTradingDetails(regID)
@@ -81,7 +77,7 @@ class TradingDetailsServiceSpec extends SCRSSpec with SCRSMocks with TradingDeta
 
       mockHttpGet[Option[TradingDetails]]("testUrl", None)
 
-      when(mockCompRegConnector.retrieveTradingDetails(Matchers.eq(regID))(Matchers.any[HeaderCarrier]()))
+      when(mockCompanyRegistrationConnector.retrieveTradingDetails(Matchers.eq(regID))(Matchers.any[HeaderCarrier]()))
         .thenReturn(Future.successful(None))
 
       val result = TestService.retrieveTradingDetails(regID)

--- a/test/views/SummarySpec.scala
+++ b/test/views/SummarySpec.scala
@@ -37,8 +37,6 @@ class SummarySpec extends SCRSSpec with SCRSFixtures with AccountingDetailsFixtu
 
   implicit val hcWithExtraHeaders: HeaderCarrier = HeaderCarrier().withExtraHeaders("Accept" -> "application/vnd.hmrc.1.0+json")
 
-
-  val mockMetaDataService = mock[MetaDataService]
   val applicantData = AboutYouChoice("Director")
   val mockNavModelRepoObj = mockNavModelRepo
 

--- a/test/views/WelcomeSpec.scala
+++ b/test/views/WelcomeSpec.scala
@@ -34,6 +34,7 @@ class WelcomeSpec extends UnitSpec with WithFakeApplication {
 		"make sure that welcome page has the correct elements for when PAYE feature switch DISABLED" in new SetupPage {
 			System.clearProperty("feature.paye")
 			System.setProperty("feature.paye", "false")
+			System.setProperty("feature.signPosting", "false")
 			val result = controller.show()(FakeRequest())
 			val document = Jsoup.parse(contentAsString(result))
 
@@ -59,6 +60,7 @@ class WelcomeSpec extends UnitSpec with WithFakeApplication {
 		"make sure that welcome page has the correct elements for when PAYE feature switch ENABLED" in new SetupPage {
 			System.clearProperty("feature.paye")
 			System.setProperty("feature.paye", "true")
+			System.setProperty("feature.signPosting", "false")
 			val result = controller.show()(FakeRequest())
 			val document = Jsoup.parse(contentAsString(result))
 


### PR DESCRIPTION
Under this feature flag:

* /welcome is now permanent redirect to /post-sign-in
* Removal of the email with link to get back to the service
* User is routed to CREFE if they start a new registration