### PR TITLE
Update service and add styles to adjust header layout

### DIFF
--- a/app/views/timeout.scala.html
+++ b/app/views/timeout.scala.html
@@ -21,10 +21,6 @@
         <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.timeout.description")</h1>
     </header>
 
-    <p>@Messages("page.timeout.p1")</p>
-
     <div class="form-group">@Messages("page.timeout.p2")
         <a href="@{controllers.reg.routes.SignInOutController.postSignIn(None)}">@Messages("page.timeout.url")</a>.</div>
-
-
 }

--- a/conf/messages
+++ b/conf/messages
@@ -34,9 +34,8 @@ common.period                                                       = .
 
 ## Timeout page
 page.timeout.description                                            = Your session has timed out due to inactivity
-page.timeout.p1                                                     = Your answers have been saved.
-page.timeout.p2                                                     = Sign in to
-page.timeout.url                                                    = continue registration
+page.timeout.p2                                                     = Sign back in to
+page.timeout.url                                                    = set up a limited company and register for Corporation Tax
 
 
 ## Welcome page
@@ -234,8 +233,8 @@ page.verification.create-new-account.bottomLink                     = Create a n
 
 page.verification.verify-your-email.title                           = Confirm your email address
 page.verification.verify-your-email.description                     = We''re going to send an email to {0}.
-page.verification.verify-your-email.p1                              = Look for an email from the GOV.UK team with the subject ''Confirm your email address''. Click the link in the email to confirm your address.
-page.verification.verify-your-email.p2                              = After you''ve done this, you''ll get another email with the subject ''Access the "Register your company" service''. It has a link you can use to access the service at any point in the future.
+page.verification.verify-your-email.p1                              = Look for an email from the GOV.UK team with the subject ''Confirm your email address - Set up a limited company and register for Corporation Tax service''. Click the link in the email to confirm your address.
+page.verification.verify-your-email.p2                              = After you''ve done this, you''ll get another email with the subject ''Access the Set up a limited company and register for Corporation Tax service''. It has a link you can use to access the service at any point in future.
 page.verification.verify-your-email.dropdown-title                  = If you haven''t received a confirmation email
 page.verification.verify-your-email.dropdown-text1                  = Check your junk folder. If it''s not there, you''ll need to
 page.verification.verify-your-email.dropdown-link1                  = start again

--- a/conf/messages
+++ b/conf/messages
@@ -6,7 +6,7 @@ global.error.heading                                                = Sorry, we'
 global.error.message                                                = You can try again by <a href={0}>restarting</a> your registration.
 
 ## Common
-common.service.name                                                 = Register your company
+common.service.name                                                 = Set up a limited company and register for Corporation Tax
 common.button.next                                                  = Next
 common.button.continue                                              = Continue
 common.button.submit                                                = Submit

--- a/public/stylesheets/header-adjust.css
+++ b/public/stylesheets/header-adjust.css
@@ -1,0 +1,29 @@
+/* This is an local CSS adjustment to the header in the GOV UK template */
+
+/*
+	The template header grid split is
+	1/3 for .header-global that contains the GOV.UK logo and crest
+	1/2's for .header-proposition that contains the service name and sign out link if available
+
+	The below code adjusts .header-global to arbitrary 20% with a min-width so that the logo doesn't break and .header-proposition to 80%
+*/
+
+/*
+	If the name changes (shortens) or the template changes (unlikely), then this will need to be either removed or updated, preferrably removed.
+
+	There is potential for this to be included in HMRC Assets Frontend with a modifier class so that it doesn't break any services using the template, but those with longer names can use the modifier class to adjust their header.
+*/
+
+@media (min-width: 769px) {
+	#global-header.with-proposition .header-wrapper .header-global {
+	    width: 20%;
+	    min-width: 185px;
+	}	
+}
+
+@media (min-width: 769px) {
+	#global-header.with-proposition .header-wrapper .header-proposition {
+	    width: 80%;
+	}
+}
+

--- a/public/stylesheets/scrs-styling.css
+++ b/public/stylesheets/scrs-styling.css
@@ -1,3 +1,4 @@
+@import 'header-adjust.css';
 @import 'form-validation.css';
 @import 'taas.css';
 @import 'dashboard.css';


### PR DESCRIPTION
This work updates the service name to 'Set up a limited company and register for Corporation Tax'. This however extends the service name further across the page, thus forcing the 'sign in/out' link to drop below, breaking the layout.

I have added some styles which adjust the layout from a 1/3 | 2/3's split to a 20% | 80% split and set the logo with a minimum width so that doesn't break in the lower screen width range of the tablet breakpoint.

## Before
<img width="973" alt="screen shot 2018-04-12 at 14 35 12" src="https://user-images.githubusercontent.com/1692222/38680667-c83599b4-3e5e-11e8-876d-9e5d5befb541.png">

## After
<img width="975" alt="screen shot 2018-04-12 at 14 34 37" src="https://user-images.githubusercontent.com/1692222/38680683-d0e40c6c-3e5e-11e8-8a2a-ece5d23dd55d.png">
