### PR TITLE
SCRS-11570: Stop showing RO as option for PPOB if can't normalise

### DIFF
--- a/app/models/CompanyDetails.scala
+++ b/app/models/CompanyDetails.scala
@@ -146,7 +146,15 @@ case class CHROAddress(premises : String,
                        country : String = "UK",
                        po_box : Option[String],
                        postal_code : Option[String],
-                       region : Option[String])
+                       region : Option[String]) {
+
+  def mkString: String = {
+    s"""$premises $address_line_1${address_line_2.fold("")(l2 => s", $l2,")}
+      | $locality${region.fold("")(r => s", $r,")}
+      |${postal_code.fold("")(pc => s" $pc, ")}$country""".stripMargin
+  }
+
+}
 
 object CHROAddress extends CHAddressValidator {
 

--- a/app/models/NewAddress.scala
+++ b/app/models/NewAddress.scala
@@ -48,6 +48,8 @@ object NewAddress {
 
   val readAddressType: Reads[String] = (__ \\ "addressType").read[String]
 
+
+
   val roReads: Reads[NewAddress] = new Reads[NewAddress] {
     def reads(json: JsValue): JsResult[NewAddress] = {
 
@@ -110,6 +112,18 @@ object NewAddress {
       (ppobPath ++ (__ \ "postCode")).formatNullable[String] and
       (ppobPath ++ (__ \ "country")).formatNullable[String] and
       (ppobPath ++ (__ \ "auditRef")).formatNullable[String]
+    )(NewAddress.apply, unlift(NewAddress.unapply))
+  }
+
+  val verifyRoToPPOB: Format[NewAddress] = {
+    (
+      (__ \ "addressLine1").format[String] and
+        (__ \ "addressLine2").format[String] and
+        (__ \ "addressLine3").formatNullable[String] and
+        (__ \ "addressLine4").formatNullable[String] and
+        (__ \ "postCode").formatNullable[String] and
+        (__ \ "country").formatNullable[String] and
+        (__ \ "auditRef").formatNullable[String]
     )(NewAddress.apply, unlift(NewAddress.unapply))
   }
 

--- a/app/views/reg/PrinciplePlaceOfBusiness.scala.html
+++ b/app/views/reg/PrinciplePlaceOfBusiness.scala.html
@@ -14,14 +14,14 @@
  * limitations under the License.
  *@
 
-@(ppobForm: Form[PPOBChoice], ROAddress: NewAddress, PPOBAddress: Option[NewAddress])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
+@(ppobForm: Form[PPOBChoice], ROAddress: Option[CHROAddress], PPOBAddress: Option[NewAddress])(implicit request: Request[_], messages: Messages, appConfig: config.AppConfig)
 
 @import uk.gov.hmrc.play.views.html.helpers.{form, input}
 @import views.html.helpers.{inputRadioGroup, errorSummary}
 
-@PPOBIsEqualToRO = @{PPOBAddress match {
-    case Some(ppob) => ppob.isEqualTo(ROAddress)
-    case _ => false
+@PPOBIsEqualToRO = @{ (ROAddress, PPOBAddress) match {
+ case (Some(ro), Some(ppob)) => ppob.addressLine1 == ro.address_line_1 && ppob.postcode == ro.postal_code
+ case _ => false
 }}
 
 @main_template(title = Messages("page.reg.ppob.description")) {
@@ -60,7 +60,7 @@
             @inputRadioGroup(
                 ppobForm("addressChoice"),
                 PPOBAddress.fold(Seq.empty[(String, String)])(PPOBAddr => Seq("PPOB" -> PPOBAddr.mkString))
-                  ++ (if(PPOBIsEqualToRO) Seq.empty[(String, String)] else Seq("RO" -> ROAddress.mkString))
+                  ++ (if(PPOBIsEqualToRO) Seq.empty[(String, String)] else if(ROAddress.nonEmpty)(Seq("RO" ->  ROAddress.get.mkString))else Seq.empty)
                   ++ Seq("Other" -> messages("page.reg.ppob.differentAddress")),
                 '_labelClass -> "block-label radio-label",
                 '_legend -> Messages("page.reg.ppob.description"),

--- a/test/controllers/PPOBControllerSpec.scala
+++ b/test/controllers/PPOBControllerSpec.scala
@@ -112,11 +112,15 @@ class PPOBControllerSpec extends SCRSSpec with PPOBFixture with WithFakeApplicat
     }
   }
 
+
+
+
   "show" should {
 
     "return a 200 and show the page when check status returns Some of reg id" in new Setup {
       mockCheckStatus()
-
+      when(mockPPOBService.fetchAddressesAndChoice(Matchers.any())(Matchers.any()))
+        .thenReturn(Future.successful(Some(CHROAddress("38", "line 1", None, "Telford", "UK", None, None, None)), Some(NewAddress("line 1", "line 2", None, None, None, None, None)), PPOBChoice("")))
       showWithAuthorisedUser(controller.show) {
         result =>
           status(result) shouldBe OK
@@ -132,33 +136,6 @@ class PPOBControllerSpec extends SCRSSpec with PPOBFixture with WithFakeApplicat
         }
       }
     }
-
-  "addressChoice" should {
-
-    val ppobDefined = Some("thing")
-    val ppobUndefined = None
-
-    val ctRegWithRO = buildCorporationTaxModel()
-    val ctReg = buildCorporationTaxModel(addressType = "")
-
-    "return a PPOBChoice with a value of PPOB if the supplied ppob option is defined" in new Setup {
-      val result = controller.addressChoice(ppobDefined, ctRegWithRO)
-
-      result shouldBe PPOBChoice("PPOB")
-    }
-
-    "return a PPOBChoice with a value of RO if the supplied ppob option is undefined and the addressType on the ctReg is RO" in new Setup {
-      val result = controller.addressChoice(ppobUndefined, ctRegWithRO)
-
-      result shouldBe PPOBChoice("RO")
-    }
-
-    "return a PPOBChoice with a blank value if the supplied ppob option is undefined and the addressType on the ctReg is not RO" in new Setup {
-      val result = controller.addressChoice(ppobUndefined, ctReg)
-
-      result shouldBe PPOBChoice("")
-    }
-  }
 
   "submit" should {
 


### PR DESCRIPTION
# SCRS-11570: Stop showing RO as option for PPOB if can't normalise

**New feature** 

* Make a request to the backend to see if the RO can be normalised (valid for DES submission). If it can, display the RO as an option. If it cannot, only display the "Different address" option.
* Send RO addresses to the backend as PPOB if selected.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack & Performance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message