### PR TITLE
SCRS-10604 Added in renew Session update keystore functionality. when…

### DIFF
--- a/app/controllers/reg/SignInOutController.scala
+++ b/app/controllers/reg/SignInOutController.scala
@@ -202,7 +202,9 @@ trait SignInOutController extends FrontendController with ControllerErrorHandler
             "Access-Control-Allow-Credentials" -> "true"
           )
         }
-        Future.successful(Ok.sendFile(new File("conf/renewSession.jpg")).as("image/jpeg").withHeaders(headers: _*))
+        updateLastActionTimestamp map { _ =>
+          Ok.sendFile(new File("conf/renewSession.jpg")).as("image/jpeg").withHeaders(headers: _*)
+        }
       }
   }
 

--- a/app/services/CommonService.scala
+++ b/app/services/CommonService.scala
@@ -16,6 +16,8 @@
 
 package services
 
+import java.time.LocalDate
+
 import connectors.KeystoreConnector
 import play.api.Logger
 import uk.gov.hmrc.http.HeaderCarrier
@@ -36,12 +38,15 @@ trait CommonService {
       case None =>
         Logger.error(s"[CommonService] [fetchRegistrationID] - Could not find a registration ID in keystore")
         throw RegistrationIDNotFoundException
-
     }
   }
 
   def cacheRegistrationID(registrationID: String)(implicit hc: HeaderCarrier): Future[CacheMap] = {
     keystoreConnector.cache("registrationID", registrationID)
+  }
+
+  def updateLastActionTimestamp()(implicit hc: HeaderCarrier): Future[CacheMap] = {
+    keystoreConnector.cache("lastActionTimestamp", LocalDate.now)
   }
 
 }

--- a/it/filters/SessionIdFilterISpec.scala
+++ b/it/filters/SessionIdFilterISpec.scala
@@ -15,8 +15,6 @@ class SessionIdFilterISpec extends IntegrationSpecBase
   with FakeAppConfig
   with MessagesHelper {
 
-  val mockHost = WiremockHelper.wiremockHost
-  val mockPort = WiremockHelper.wiremockPort
 
   override implicit lazy val app: Application = GuiceApplicationBuilder()
     .configure(fakeConfig())

--- a/it/itutil/IntegrationSpecBase.scala
+++ b/it/itutil/IntegrationSpecBase.scala
@@ -18,6 +18,7 @@ package itutil
 import org.scalatest._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatestplus.play.OneServerPerSuite
+import play.api.test.FakeApplication
 import uk.gov.hmrc.play.test.UnitSpec
 import utils.{FeatureSwitch, SCRSFeatureSwitches}
 
@@ -25,6 +26,10 @@ trait IntegrationSpecBase extends UnitSpec
   with GivenWhenThen
   with OneServerPerSuite with ScalaFutures with IntegrationPatience with Matchers
   with WiremockHelper with BeforeAndAfterEach with BeforeAndAfterAll {
+
+  val mockHost = WiremockHelper.wiremockHost
+  val mockPort = WiremockHelper.wiremockPort
+  val testkey = "Fak3-t0K3n-f0r-pUBLic-r3p0SiT0rY"
 
   def setupFeatures(cohoFirstHandOff: Boolean = false,
                     businessActivitiesHandOff: Boolean = false,

--- a/it/itutil/RequestsFinder.scala
+++ b/it/itutil/RequestsFinder.scala
@@ -1,0 +1,31 @@
+
+package itutil
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import play.api.libs.json.{JsValue, Json}
+
+trait RequestsFinder {
+  def getRequestBody(httpMethod: String, url: String): String = httpMethod.toLowerCase match {
+    case "get"    => findAll(getRequestedFor(urlMatching(url))).get(0).getBodyAsString
+    case "post"   => findAll(postRequestedFor(urlMatching(url))).get(0).getBodyAsString
+    case "patch"  => findAll(patchRequestedFor(urlMatching(url))).get(0).getBodyAsString
+    case "delete" => findAll(deleteRequestedFor(urlMatching(url))).get(0).getBodyAsString
+    case "put"    => findAll(putRequestedFor(urlMatching(url))).get(0).getBodyAsString
+    case _ => throw new IllegalArgumentException("wrong HTTP Method")
+  }
+
+  def getGETRequestJsonBody(url: String): JsValue =
+    Json.parse(getRequestBody("get", url))
+
+  def getPUTRequestJsonBody(url: String): JsValue =
+    Json.parse(getRequestBody("put", url))
+
+  def getPOSTRequestJsonBody(url: String): JsValue =
+    Json.parse(getRequestBody("post", url))
+
+  def getPATCHRequestJsonBody(url: String): JsValue =
+    Json.parse(getRequestBody("patch", url))
+
+  def getDELETERequestJsonBody(url: String): JsValue =
+    Json.parse(getRequestBody("delete", url))
+}

--- a/it/statusapi/CohoStatusApiISpec.scala
+++ b/it/statusapi/CohoStatusApiISpec.scala
@@ -22,12 +22,7 @@ import play.api.test.FakeApplication
 
 class CohoStatusApiISpec extends IntegrationSpecBase with FakeAppConfig with LoginStub {
 
-  val mockHost = WiremockHelper.wiremockHost
-  val mockPort = WiremockHelper.wiremockPort
-
   override implicit lazy val app = FakeApplication(additionalConfiguration = fakeConfig())
-
-  private def client(path: String) = ws.url(s"http://localhost:$port/register-your-company$path").withFollowRedirects(false)
   private def intClient(path: String) = ws.url(s"http://localhost:$port/internal$path").withFollowRedirects(false)
 
   "Submission status proxy" should {

--- a/it/submissionapi/SubmissionApiISpec.scala
+++ b/it/submissionapi/SubmissionApiISpec.scala
@@ -22,9 +22,6 @@ import play.api.test.FakeApplication
 
 class SubmissionApiISpec extends IntegrationSpecBase with FakeAppConfig with LoginStub {
 
-  val mockHost = WiremockHelper.wiremockHost
-  val mockPort = WiremockHelper.wiremockPort
-
   override implicit lazy val app = FakeApplication(additionalConfiguration = fakeConfig(
     "application.router" -> "testOnlyDoNotUseInAppConf.Routes"
   ))

--- a/it/www/AccountingDetailsISpec.scala
+++ b/it/www/AccountingDetailsISpec.scala
@@ -18,7 +18,7 @@ package www
 import java.util.UUID
 
 import com.github.tomakehurst.wiremock.client.WireMock._
-import itutil.{FakeAppConfig, IntegrationSpecBase, LoginStub, WiremockHelper}
+import itutil.{FakeAppConfig, IntegrationSpecBase, LoginStub}
 import org.jsoup.Jsoup
 import play.api.http.HeaderNames
 import play.api.libs.json.Json
@@ -27,15 +27,8 @@ import play.api.test.FakeApplication
 
 class AccountingDetailsISpec extends IntegrationSpecBase with LoginStub with FakeAppConfig {
 
-  val mockHost = WiremockHelper.wiremockHost
-  val mockPort = WiremockHelper.wiremockPort
-
   override implicit lazy val app = FakeApplication(additionalConfiguration = fakeConfig())
-
-  private def client(path: String) = ws.url(s"http://localhost:$port/register-your-company$path").withFollowRedirects(false)
-
   val userId = "/bar/foo"
-
   def statusResponseFromCR(status:String = "draft", rID:String = "5") =
     s"""
        |{
@@ -60,7 +53,7 @@ class AccountingDetailsISpec extends IntegrationSpecBase with LoginStub with Fak
       stubKeystore(SessionId, "5")
 
       stubGet("/company-registration/corporation-tax-registration/5/accounting-details", 404, "")
-      val fResponse = client("/when-start-business").
+      val fResponse = buildClient("/when-start-business").
         withHeaders(HeaderNames.COOKIE -> getSessionCookie(userId=userId)).
         get()
 
@@ -93,7 +86,7 @@ class AccountingDetailsISpec extends IntegrationSpecBase with LoginStub with Fak
 
       stubGet("/company-registration/corporation-tax-registration/5/accounting-details", 200, crResponse)
 
-      val fResponse = client("/when-start-business").
+      val fResponse = buildClient("/when-start-business").
         withHeaders(HeaderNames.COOKIE -> getSessionCookie(userId=userId)).
         get()
 
@@ -124,7 +117,7 @@ class AccountingDetailsISpec extends IntegrationSpecBase with LoginStub with Fak
 
       stubGet("/company-registration/corporation-tax-registration/5/accounting-details", 200, crResponse)
 
-      val fResponse = client("/when-start-business").
+      val fResponse = buildClient("/when-start-business").
         withHeaders(HeaderNames.COOKIE -> getSessionCookie(userId=userId)).
         get()
 
@@ -150,7 +143,7 @@ class AccountingDetailsISpec extends IntegrationSpecBase with LoginStub with Fak
 
       val sessionCookie = getSessionCookie(Map("csrfToken" -> csrfToken), userId)
 
-      val fResponse = client("/when-start-business").
+      val fResponse = buildClient("/when-start-business").
         withHeaders(HeaderNames.COOKIE -> sessionCookie, "Csrf-Token" -> "nocheck").
         post(Map(
           "csrfToken"->Seq("xxx-ignored-xxx"),
@@ -172,5 +165,4 @@ class AccountingDetailsISpec extends IntegrationSpecBase with LoginStub with Fak
       (json \ "startDateOfBusiness").as[String] shouldBe "2019-01-02"
     }
   }
-
 }

--- a/it/www/BasicCompanyDetailsControllerISpec.scala
+++ b/it/www/BasicCompanyDetailsControllerISpec.scala
@@ -19,13 +19,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class BasicCompanyDetailsControllerISpec extends IntegrationSpecBase with MongoSpecSupport with LoginStub with FakeAppConfig {
 
-  val mockHost = WiremockHelper.wiremockHost
-  val mockPort = WiremockHelper.wiremockPort
-  val testkey = "Fak3-t0K3n-f0r-pUBLic-r3p0SiT0rY"
-
   override implicit lazy val app = FakeApplication(additionalConfiguration = fakeConfig("microservice.services.JWE.key" -> testkey))
-
-  private def client(path: String) = ws.url(s"http://localhost:$port/register-your-company$path").withFollowRedirects(false)
 
   val userId = "/bar/foo"
   val regId = "regId5"
@@ -159,7 +153,7 @@ class BasicCompanyDetailsControllerISpec extends IntegrationSpecBase with MongoS
 
       stubGetUserDetails(userId)
 
-      val fResponse = client("/basic-company-details").
+      val fResponse = buildClient("/basic-company-details").
         withHeaders(HeaderNames.COOKIE -> sessionCookie, "Csrf-Token" -> "nocheck").
         get()
 
@@ -185,7 +179,7 @@ class BasicCompanyDetailsControllerISpec extends IntegrationSpecBase with MongoS
 
       stubKeystore(SessionId, regId)
 
-      val fResponse = client(returnEncryptedRequest(Jwe.encrypt[JsObject](returnPayloadJson).get)).
+      val fResponse = buildClient(returnEncryptedRequest(Jwe.encrypt[JsObject](returnPayloadJson).get)).
         withHeaders(HeaderNames.COOKIE -> sessionCookie, "Csrf-Token" -> "nocheck").
         get()
 
@@ -205,7 +199,7 @@ class BasicCompanyDetailsControllerISpec extends IntegrationSpecBase with MongoS
 
       stubKeystore(SessionId, regId)
 
-      val fResponse = client(returnEncryptedRequest("malformed-encrypted-json")).
+      val fResponse = buildClient(returnEncryptedRequest("malformed-encrypted-json")).
         withHeaders(HeaderNames.COOKIE -> sessionCookie, "Csrf-Token" -> "nocheck").
         get()
 

--- a/it/www/DashboardControllerISpec.scala
+++ b/it/www/DashboardControllerISpec.scala
@@ -25,8 +25,7 @@ import play.api.libs.json.Json
 import play.api.test.FakeApplication
 
 class DashboardControllerISpec extends IntegrationSpecBase with LoginStub with FakeAppConfig {
-  val mockHost = WiremockHelper.wiremockHost
-  val mockPort = WiremockHelper.wiremockPort
+
 
   override implicit lazy val app = FakeApplication(additionalConfiguration = fakeConfig(
     "microservice.services.paye-registration.host" -> s"$mockHost",

--- a/it/www/HandOffsISpec.scala
+++ b/it/www/HandOffsISpec.scala
@@ -9,12 +9,8 @@ import play.api.test.FakeApplication
 
 class HandOffsISpec extends IntegrationSpecBase with LoginStub with FakeAppConfig with HandOffFixtures {
 
-  val mockHost = WiremockHelper.wiremockHost
-  val mockPort = WiremockHelper.wiremockPort
-
   override implicit lazy val app: Application = FakeApplication(additionalConfiguration = fakeConfig())
 
-  def client(path: String) = ws.url(s"http://localhost:$port/register-your-company$path").withFollowRedirects(false)
   def followRequest(path: String) = ws.url(s"http://localhost:$port$path").withFollowRedirects(false)
 
   val userId = "test-user-id"
@@ -70,7 +66,7 @@ class HandOffsISpec extends IntegrationSpecBase with LoginStub with FakeAppConfi
       stubKeystore(SessionId, regId, 404)
 
       When(s"A GET request is made to $url with a payload")
-      val response = client(s"$url?request=$payload")
+      val response = buildClient(s"$url?request=$payload")
         .withHeaders(HeaderNames.COOKIE -> getSessionCookie(userId = userId))
         .get()
 

--- a/it/www/RegistrationConfirmationISpec.scala
+++ b/it/www/RegistrationConfirmationISpec.scala
@@ -35,10 +35,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class RegistrationConfirmationISpec extends IntegrationSpecBase with MongoSpecSupport with LoginStub with FakeAppConfig {
 
-  val mockHost = WiremockHelper.wiremockHost
-  val mockPort = WiremockHelper.wiremockPort
-  val testkey = "Fak3-t0K3n-f0r-pUBLic-r3p0SiT0rY"
-
   override implicit lazy val app = FakeApplication(additionalConfiguration = fakeConfig("microservice.services.JWE.key" -> testkey))
 
   private def client(path: String) = ws.url(s"http://localhost:$port/register-your-company$path").withFollowRedirects(false)
@@ -49,7 +45,6 @@ class RegistrationConfirmationISpec extends IntegrationSpecBase with MongoSpecSu
   class Setup {
     val rc = app.injector.instanceOf[ReactiveMongoComponent]
     val repo = new NavModelRepo(rc)
-    //await(repo.repository.drop)
     await(repo.repository.ensureIndexes)
   }
   def confirmationEncryptedRequest(encrypted : String) = s"/registration-confirmation?request=$encrypted"
@@ -409,6 +404,4 @@ class RegistrationConfirmationISpec extends IntegrationSpecBase with MongoSpecSu
       response.header(HeaderNames.LOCATION).get should include("/register-your-company/something-went-wrong")
     }
   }
-
-
 }

--- a/it/www/ReturningUserControllerISpec.scala
+++ b/it/www/ReturningUserControllerISpec.scala
@@ -27,12 +27,9 @@ import scala.concurrent.Future
 
 class ReturningUserControllerISpec extends IntegrationSpecBase with LoginStub with BeforeAndAfterEach with FakeAppConfig {
 
-  val mockHost = WiremockHelper.wiremockHost
-  val mockPort = WiremockHelper.wiremockPort
 
   override implicit lazy val app = FakeApplication(additionalConfiguration = fakeConfig())
 
-  private def client(path: String) = ws.url(s"http://localhost:$port/register-your-company$path").withFollowRedirects(false)
 
   val userId = "/wibble"
 
@@ -48,7 +45,7 @@ class ReturningUserControllerISpec extends IntegrationSpecBase with LoginStub wi
 
       setupFeatures()
 
-      val post: Future[WSResponse] = client("/setting-up-new-limited-company")
+      val post: Future[WSResponse] = buildClient("/setting-up-new-limited-company")
         .withHeaders(HeaderNames.COOKIE -> sessionCookie, "Csrf-Token" -> "nocheck")
         .post(map)
       val response = await(post)
@@ -71,7 +68,7 @@ class ReturningUserControllerISpec extends IntegrationSpecBase with LoginStub wi
 
       setupFeatures(signPosting = true)
 
-      val post: Future[WSResponse] = client("/setting-up-new-limited-company")
+      val post: Future[WSResponse] = buildClient("/setting-up-new-limited-company")
         .withHeaders(HeaderNames.COOKIE -> sessionCookie, "Csrf-Token" -> "nocheck")
         .post(map)
       val response = await(post)

--- a/it/www/VerifyYourEmailISpec.scala
+++ b/it/www/VerifyYourEmailISpec.scala
@@ -26,12 +26,8 @@ import scala.concurrent.duration.FiniteDuration
 
 class VerifyYourEmailISpec extends IntegrationSpecBase with LoginStub with BeforeAndAfterEach with FakeAppConfig {
 
-  val mockHost = WiremockHelper.wiremockHost
-  val mockPort = WiremockHelper.wiremockPort
 
   override implicit lazy val app = FakeApplication(additionalConfiguration = fakeConfig())
-
-  private def client(path: String) = ws.url(s"http://localhost:$port/register-your-company$path").withFollowRedirects(false)
 
   val userId = "/wibble"
 
@@ -61,7 +57,7 @@ class VerifyYourEmailISpec extends IntegrationSpecBase with LoginStub with Befor
       val email = "foo@bar.wibble"
       stubKeystore(SessionId, "5",  email)
 
-      val fResponse = client("/sent-an-email").
+      val fResponse = buildClient("/sent-an-email").
         withHeaders(HeaderNames.COOKIE -> getSessionCookie(userId=userId)).
         get()
 
@@ -77,7 +73,7 @@ class VerifyYourEmailISpec extends IntegrationSpecBase with LoginStub with Befor
     "redirect to sign-in when not logged in" in {
       stubAuthorisation(401, None)
 
-      val response = await(client("/sent-an-email").get())
+      val response = await(buildClient("/sent-an-email").get())
 
       response.status shouldBe 303
 

--- a/test/controllers/SignInOutControllerSpec.scala
+++ b/test/controllers/SignInOutControllerSpec.scala
@@ -16,6 +16,8 @@
 
 package controllers
 
+import java.time.LocalDate
+
 import builders.AuthBuilder
 import connectors._
 import controllers.reg.SignInOutController
@@ -32,6 +34,7 @@ import play.api.test.Helpers.{contentType, _}
 import services.{EmailVerificationService, EnrolmentsService}
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, ~}
 import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolments}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.binders.ContinueUrl
 import uk.gov.hmrc.play.test.WithFakeApplication
@@ -387,6 +390,9 @@ class SignInOutControllerSpec extends SCRSSpec
 
   "renewSession" should {
     "return 200 when hit with Authorised User" in new Setup {
+      when(mockKeystoreConnector.cache(Matchers.contains("lastActionTimestamp"), Matchers.any[LocalDate]())(Matchers.any[HeaderCarrier](), Matchers.any()))
+        .thenReturn(Future.successful(cacheMap))
+
       showWithAuthorisedUser(controller.renewSession()) { a =>
         status(a) shouldBe 200
         contentType(a) shouldBe Some("image/jpeg")
@@ -397,6 +403,9 @@ class SignInOutControllerSpec extends SCRSSpec
     }
 
     "return CORS headers when a cors host is supplied" in new Setup(Some("http://localhost:12345")) {
+      when(mockKeystoreConnector.cache(Matchers.contains("lastActionTimestamp"), Matchers.any[LocalDate]())(Matchers.any[HeaderCarrier](), Matchers.any()))
+        .thenReturn(Future.successful(cacheMap))
+
       showWithAuthorisedUser(controller.renewSession()) { a =>
         status(a) shouldBe 200
         header("Access-Control-Allow-Origin", a) shouldBe Some("http://localhost:12345")

--- a/test/services/CommonServiceSpec.scala
+++ b/test/services/CommonServiceSpec.scala
@@ -16,10 +16,17 @@
 
 package services
 
+import java.time.LocalDate
+
 import helpers.SCRSSpec
-import play.api.libs.json.Json
+import org.mockito.Matchers
+import org.mockito.Mockito.when
+import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.cache.client.CacheMap
 import utils.{SCRSException, SCRSExceptions}
+
+import scala.concurrent.Future
 
 class CommonServiceSpec extends SCRSSpec {
 
@@ -55,6 +62,17 @@ class CommonServiceSpec extends SCRSSpec {
       mockKeystoreCache("registrationID", "12345", cacheMap)
 
       await(service.cacheRegistrationID("12345")) shouldBe cacheMap
+    }
+  }
+
+  "updateLastActionTimestamp" should {
+    val timestampCacheMap = CacheMap("lastActionTimestamp", Map("lastActionTimestamp" -> Json.toJson(LocalDate.now())))
+
+    "cache the passed timestamp in keystore" in new Setup {
+      when(mockKeystoreConnector.cache(Matchers.contains("lastActionTimestamp"), Matchers.any[LocalDate]())(Matchers.any[HeaderCarrier](), Matchers.any()))
+        .thenReturn(Future.successful(timestampCacheMap))
+
+      await(service.updateLastActionTimestamp()) shouldBe timestampCacheMap
     }
   }
 }


### PR DESCRIPTION
SCRS-10604 - refactor keystore expiration handling
**New feature**

SCRS-10604 Added in renew Session update keystore functionality. when the user hits renew session it also updates a timestamp in keystore which will keep the record alive when in companies house, also refactored IT tests to remove duplicate code, also added RequestsFinder to grab requests for an it tests to check the json being sent to other microservices

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
