### PR TITLE
SCRS-11347 Changed javascript so GA Widget can group by action

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.co
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.8.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.9.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
 

--- a/public/javascripts/AccountingDates.js
+++ b/public/javascripts/AccountingDates.js
@@ -9,6 +9,6 @@ $(document).ready($(function() {
             }
         });
 
-        ga("send", "event", "UserChoice", "AccountingDates", selection);
+        ga("send", "event", "AccountingDatesChoice", selection);
     });
 }));


### PR DESCRIPTION
# SCRS-11347 - Amending previous attempt

**Bug fix**

In order to meet the acceptance criteria, the GA event has been amended. This is due to a limitation of GA Pie Charts being unable to group by "value". The new event puts the unique event detail into the "action".
There is also a new "Category" to better describe the scenario now that we have fewer descriptive elements in the GA event.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
