### PR TITLE
SCRS-11044 Added new test endpoint to incorporate a registration 

### DIFF
--- a/app/controllers/test/SubmissionTriggerController.scala
+++ b/app/controllers/test/SubmissionTriggerController.scala
@@ -18,20 +18,30 @@ package controllers.test
 
 import connectors.CompanyRegistrationConnector
 import play.api.mvc.Action
+import services.internal.CheckIncorporationService
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
 object SubmissionTriggerController extends SubmissionTriggerController {
   val cRConnector = CompanyRegistrationConnector
+  val checkIncorpService = CheckIncorporationService
 }
 
 trait SubmissionTriggerController extends FrontendController {
 
-  val cRConnector : CompanyRegistrationConnector
+  val cRConnector: CompanyRegistrationConnector
+  val checkIncorpService: CheckIncorporationService
 
   def triggerSubmissionCheck = Action.async {
     implicit request =>
       cRConnector.checkAndProcessNextSubmission.map { res =>
         new Status(res.status)(res.body)
+      }
+  }
+
+  def incorporate(txId: String, accepted: Boolean) = Action.async {
+    implicit request =>
+      checkIncorpService.incorporateTransactionId(txId, accepted) map { success =>
+        Ok(if(success) s"[SUCCESS] incorporating $txId" else s"[FAILED] to incorporate $txId")
       }
   }
 }

--- a/conf/test.routes
+++ b/conf/test.routes
@@ -44,3 +44,5 @@ GET      /dashboardStubbed                               controllers.test.TestEn
 GET      /hand-off-6                                     controllers.test.TestEndpointController.handOff6(transactionId: Option[String])
 
 GET      /edit-session/:newSessionId                     controllers.test.EditSessionController.editSession(newSessionId)
+
+GET      /incorporate/:txId                              controllers.test.SubmissionTriggerController.incorporate(txId, accepted: Boolean ?= true)

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -1,6 +1,5 @@
 import play.routes.compiler.StaticRoutesGenerator
 import sbt.Keys._
-import sbt.Tests.{Group, SubProcess}
 import sbt._
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
@@ -11,7 +10,6 @@ trait MicroService {
 
   import uk.gov.hmrc._
   import DefaultBuildSettings._
-  import TestPhases._
   import uk.gov.hmrc.versioning.SbtGitVersioning
 
   val appName: String
@@ -54,20 +52,5 @@ trait MicroService {
     )
     .configs(IntegrationTest)
     .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
-    .settings(
-      Keys.fork in IntegrationTest := false,
-      unmanagedSourceDirectories in IntegrationTest <<= (baseDirectory in IntegrationTest)(base => Seq(base / "it")),
-      addTestReportOption(IntegrationTest, "int-test-reports"),
-      testGrouping in IntegrationTest := oneForkedJvmPerTest((definedTests in IntegrationTest).value),
-      parallelExecution in IntegrationTest := false)
-    .disablePlugins(sbt.plugins.JUnitXmlReportPlugin)
-    .settings(resolvers ++= Seq(Resolver.bintrayRepo("hmrc", "releases"), Resolver.jcenterRepo))
-}
-
-private object TestPhases {
-
-  def oneForkedJvmPerTest(tests: Seq[TestDefinition]) =
-    tests map {
-      test => new Group(test.name, Seq(test), SubProcess(ForkOptions(runJVMOptions = Seq("-Dtest.name=" + test.name))))
-    }
+    .settings(integrationTestSettings())
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,13 +2,13 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.co
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.11.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.10.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.1.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 

--- a/test/connectors/CompanyRegistrationConnectorSpec.scala
+++ b/test/connectors/CompanyRegistrationConnectorSpec.scala
@@ -556,25 +556,29 @@ class CompanyRegistrationConnectorSpec extends SCRSSpec with CTDataFixture with 
   "fetchAcknowledgementReference" should {
 
     "return a succcess response when an Ack ref is found" in new Setup {
-      mockHttpGet("testUrl", ConfirmationReferences("a", Some("b"), Some("c"), "BRCT00000000123"))
+      when(mockWSHttp.GET(Matchers.anyString())(Matchers.any[HttpReads[ConfirmationReferences]](), Matchers.any[HeaderCarrier](), Matchers.any()))
+        .thenReturn(Future.successful(ConfirmationReferences("a", Some("b"), Some("c"), "BRCT00000000123")))
 
       await(connector.fetchConfirmationReferences("testRegID")) shouldBe ConfirmationReferencesSuccessResponse(ConfirmationReferences("a", Some("b"), Some("c"), "BRCT00000000123"))
     }
 
     "return a bad request response if a there is a bad request to company registration" in new Setup {
-      mockHttpGet("testUrl", Future.failed(new BadRequestException("bad request")))
+      when(mockWSHttp.GET(Matchers.anyString())(Matchers.any[HttpReads[ConfirmationReferences]](), Matchers.any[HeaderCarrier](), Matchers.any()))
+        .thenReturn(Future.failed(new BadRequestException("bad request")))
 
       await(connector.fetchConfirmationReferences("testRegID")) shouldBe ConfirmationReferencesBadRequestResponse
     }
 
     "return a not found response if a record cannot be found" in new Setup {
-      mockHttpGet("testUrl", Future.failed(new NotFoundException("not found")))
+      when(mockWSHttp.GET(Matchers.anyString())(Matchers.any[HttpReads[ConfirmationReferences]](), Matchers.any[HeaderCarrier](), Matchers.any()))
+        .thenReturn(Future.failed(new NotFoundException("not found")))
 
       await(connector.fetchConfirmationReferences("testRegID")) shouldBe ConfirmationReferencesNotFoundResponse
     }
 
     "return an error response when the error is not captured by the other responses" in new Setup {
-      mockHttpGet("testUrl", Future.failed(new Exception()))
+      when(mockWSHttp.GET(Matchers.anyString())(Matchers.any[HttpReads[ConfirmationReferences]](), Matchers.any[HeaderCarrier](), Matchers.any()))
+        .thenReturn(Future.failed(new Exception()))
 
       await(connector.fetchConfirmationReferences("testRegID")) shouldBe ConfirmationReferencesErrorResponse
     }

--- a/test/mocks/WSHTTPMock.scala
+++ b/test/mocks/WSHTTPMock.scala
@@ -37,7 +37,7 @@ trait WSHTTPMock {
     }
 
     def mockHttpGet[T](url: String, thenReturn: Future[T]): OngoingStubbing[Future[T]] = {
-      when(mockWSHttp.GET[T](Matchers.anyString())(Matchers.any[HttpReads[T]](), Matchers.any[HeaderCarrier](), Matchers.any()))
+      when(mockWSHttp.GET[T](Matchers.eq(url))(Matchers.any[HttpReads[T]](), Matchers.any[HeaderCarrier](), Matchers.any()))
         .thenReturn(thenReturn)
     }
 


### PR DESCRIPTION
# SCRS-11044 - Adding the ability to incorporate a company manually

**New feature**

This commit adds a new endpoint that allows us to incorporate a registration using a transaction ID. It supports Accepted and Rejected through the use of a query string but defaults to **Accepted** if the query string is not provided.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
