### PR TITLE
Added in redirect to incorrect account type page if auth returns match exception

### DIFF
--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -25,7 +25,7 @@ private object AppDependencies {
   val compile = Seq(
     ws,
     "uk.gov.hmrc" %% "frontend-bootstrap" % "10.7.0",
-    "uk.gov.hmrc" %% "auth-client" % "2.16.0-play-25",
+    "uk.gov.hmrc" %% "auth-client" % "2.17.0-play-25",
     "uk.gov.hmrc" %% "play-partials" % "6.2.0",
     "uk.gov.hmrc" %% "url-builder" % "2.1.0",
     "uk.gov.hmrc" %% "http-caching-client" % "7.2.0",

--- a/test/utils/AuthFunctionSpec.scala
+++ b/test/utils/AuthFunctionSpec.scala
@@ -20,16 +20,17 @@ import builders.AuthBuilder
 import controllers.auth.AuthFunction
 import fixtures.LoginFixture
 import helpers.SCRSSpec
-import play.api.libs.json.{Json, Reads}
-import play.api.mvc.{Result, Results}
+import play.api.http.HeaderNames
+import play.api.mvc.Results
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.AuthorisationException
 import uk.gov.hmrc.auth.core.retrieve._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.test.WithFakeApplication
 
 import scala.concurrent.Future
+import scala.util.Try
 
 class AuthFunctionSpec extends SCRSSpec with AuthBuilder with WithFakeApplication with LoginFixture {
 
@@ -62,6 +63,68 @@ class AuthFunctionSpec extends SCRSSpec with AuthBuilder with WithFakeApplicatio
     }
   }
 
+  "authErrorHandling" should {
+    Map("case 1" -> "InsufficientConfidenceLevel",
+    "case 2" -> "UnsupportedAffinityGroup",
+    "case 3" -> "UnsupportedCredentialRole",
+    "case 4" -> "UnsupportedAuthProvider",
+    "case 9" -> "IncorrectCredentialStrength" ,
+    "case 10" -> "InsufficientEnrolments" ).foreach{
+      tst =>
+        val (test,ex) = tst
+        s"$test redirect to incorrect account type page if auth returns $ex" in new Setup {
+          Try(throw AuthorisationException.fromString(ex))
+            .recover(support.authErrorHandling()).get.header.headers(HeaderNames.LOCATION) shouldBe controllers.verification.routes.EmailVerificationController.createGGWAccountAffinityShow().url
+        }
+    }
+    "internal server error if auth returns non matching string exception" in new Setup {
+      Try(throw AuthorisationException.fromString("fudge"))
+        .recover(support.authErrorHandling()).get shouldBe Results.InternalServerError
+    }
+    Map("case 5" -> "BearerTokenExpired",
+      "case 6" -> "MissingBearerToken",
+      "case 7" -> "InvalidBearerToken",
+      "case 8" -> "SessionRecordNotFound").foreach{
+      tst =>
+        val (test, ex) = tst
+        s"$test redirect to sign in  with postsignin as continue url for $ex" in new Setup {
+          Try(throw AuthorisationException.fromString(ex))
+            .recover(support.authErrorHandling()).get.header.headers(HeaderNames.LOCATION) shouldBe "http://localhost:9025/gg/sign-in?accountType=organisation&continue=http%3A%2F%2Flocalhost%3A9970%2Fregister-your-company%2Fpost-sign-in&origin=company-registration-frontend"
+        }
+    }
+  }
+  "authErrorHandlingIncomplete" should {
+    Map("case 1" -> "InsufficientConfidenceLevel",
+      "case 2" -> "UnsupportedAffinityGroup",
+      "case 3" -> "UnsupportedCredentialRole",
+      "case 4" -> "UnsupportedAuthProvider",
+      "case 9" -> "IncorrectCredentialStrength" ,
+      "case 10" -> "InsufficientEnrolments" ).foreach{
+      tst =>
+        val (test,ex) = tst
+        s"$test redirect to incorrect account type page if auth returns $ex" in new Setup {
+          Try(throw AuthorisationException.fromString(ex))
+            .recover(support.authErrorHandlingIncomplete).get.header.headers(HeaderNames.LOCATION) shouldBe controllers.verification.routes.EmailVerificationController.createGGWAccountAffinityShow().url
+        }
+    }
+    "internal server error if auth returns non matching string exception" in new Setup {
+      Try(throw AuthorisationException.fromString("fudge"))
+        .recover(support.authErrorHandlingIncomplete).get shouldBe Results.InternalServerError
+    }
+    Map("case 5" -> "BearerTokenExpired",
+      "case 6" -> "MissingBearerToken",
+      "case 7" -> "InvalidBearerToken",
+      "case 8" -> "SessionRecordNotFound").foreach{
+      tst =>
+        val (test, ex) = tst
+        s"$test redirect to sign in  with postsignin as continue url for $ex" in new Setup {
+          Try(throw AuthorisationException.fromString(ex))
+            .recover(support.authErrorHandlingIncomplete).get.header.headers(HeaderNames.LOCATION) shouldBe controllers.reg.routes.IncompleteRegistrationController.show().url
+        }
+    }
+  }
+
+
   "ctAuthorised" should {
     "redirect to OK if the person is signed in" in new Setup {
       mockAuthorisedUser({})
@@ -80,12 +143,12 @@ class AuthFunctionSpec extends SCRSSpec with AuthBuilder with WithFakeApplicatio
       redirectLocation(result) shouldBe Some(authUrl)
     }
 
-    "return an internal server error if an auth error occurs" in new Setup {
+    "redirect to Incorrect account type server error if an auth error occurs" in new Setup {
       mockAuthFailure()
       val result = support.ctAuthorised(Results.Ok)
 
       val response = await(result)
-      response.header.status shouldBe 500
+      response.header.headers(HeaderNames.LOCATION) shouldBe controllers.verification.routes.EmailVerificationController.createGGWAccountAffinityShow().url
     }
   }
 


### PR DESCRIPTION
Redirect to incorrect account page rather than blow up (boom)
## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
