### PR TITLE
SAR-4452: Add prepop address connector

### DIFF
--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -97,6 +97,9 @@ trait FrontendAppConfig extends ServicesConfig {
   lazy val loginURL = s"$companyAuthHost$loginPath"
   lazy val logoutURL = s"$companyAuthHost$logoutPath"
 
+  def prepopAddressUrl(registrationId: String): String =
+    s"${baseUrl("business-registration")}/business-registration/$registrationId/addresses"
+
   def continueURL(handOffID: Option[String], payload: Option[String]) = s"$loginCallback${routes.SignInOutController.postSignIn(None, handOffID, payload).url}"
 
   lazy val companyRegistrationUrl: String = baseUrl("company-registration")

--- a/app/connectors/BusinessRegistrationConnector.scala
+++ b/app/connectors/BusinessRegistrationConnector.scala
@@ -17,7 +17,6 @@
 package connectors
 
 import javax.inject.Inject
-
 import config.{FrontendAppConfig, WSHttp}
 import models._
 import play.api.Logger

--- a/app/connectors/PrepopAddressConnector.scala
+++ b/app/connectors/PrepopAddressConnector.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.{FrontendAppConfig, WSHttp}
+import javax.inject.{Inject, Singleton}
+import models.Address
+import play.api.Logger
+import play.api.libs.json._
+import uk.gov.hmrc.http._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class PrepopAddressConnector @Inject()(appConfig: FrontendAppConfig,
+                                       http: WSHttp
+                                      )(implicit executionContext: ExecutionContext) {
+
+  def getPrepopAddresses(registrationId: String)(implicit hc: HeaderCarrier): Future[Option[PrepopAddresses]] =
+    http.GET[HttpResponse](appConfig.prepopAddressUrl(registrationId)) map { response =>
+      response.json.validate[PrepopAddresses] match {
+        case JsSuccess(addresses, _) =>
+          Some(addresses)
+        case JsError(errors) => {
+          Logger.error(s"[Get prepop addresses] Incoming JSON failed format validation with reason(s): $errors")
+          None
+        }
+      }
+    } recover {
+      case _: NotFoundException =>
+        Some(PrepopAddresses(Seq()))
+      case e: ForbiddenException =>
+        Logger.error(s"[Get prepop address] Forbidden request (${e.responseCode}) ${e.message}")
+        None
+      case e: Exception => {
+        Logger.error(s"[Get prepop address] Unexpected error calling business registration (${e.getMessage})")
+        None
+      }
+    }
+
+  def updatePrepopAddress(registrationId: String, address: Address)(implicit hc: HeaderCarrier): Future[Boolean] =
+    http.POST[JsValue, HttpResponse](appConfig.prepopAddressUrl(registrationId), Json.toJson(address))
+      .map (_ => true)
+      .recover {
+        case e: Exception =>
+          Logger.error(s"[Update prepop address] Unexpected error updating prepop address (${e.getMessage})")
+          false
+      }
+
+}
+case class PrepopAddresses(addresses: Seq[Address])
+
+object PrepopAddresses {
+  implicit val format: Format[PrepopAddresses] = Json.format[PrepopAddresses]
+}
+
+
+
+

--- a/it/connectors/PrepopAddressConnectorISpec.scala
+++ b/it/connectors/PrepopAddressConnectorISpec.scala
@@ -1,0 +1,97 @@
+
+package connectors
+
+import itutil.servicestubs.BusinessRegistrationStub
+import itutil.{FakeAppConfig, IntegrationSpecBase}
+import models.Address
+import play.api.http.Status._
+import play.api.libs.json.Json
+import play.api.test.FakeApplication
+import uk.gov.hmrc.http.HeaderCarrier
+
+class PrepopAddressConnectorISpec extends IntegrationSpecBase with BusinessRegistrationStub with FakeAppConfig {
+  override implicit lazy val app: FakeApplication = FakeApplication(additionalConfiguration = fakeConfig())
+
+  lazy val connector: PrepopAddressConnector = app.injector.instanceOf[PrepopAddressConnector]
+  implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
+
+  val testRegId = "12345"
+
+  trait PrepopAddressTest {
+    val addrLine1 = "line 1"
+    val addrLine2 = "line 2"
+    val addrLine3 = Some("line 3")
+    val addrLine4 = Some("line 4")
+    val postcode = Some("AB12 3YZ")
+    val country = Some("United Kingdom")
+    val testRegId = "12345"
+
+    def prepopAddressSeq(n: Int): Seq[Address] =
+      1 to n map(_ => Address(None, addrLine1, addrLine2, addrLine3, addrLine4, postcode, country))
+  }
+
+  s"GET /business-registration/$testRegId/addresses" should {
+    "return Some(PrepopAddresses)" when {
+      "there are addresses for the specified registration ID" in new PrepopAddressTest {
+        val addressSeq = prepopAddressSeq(2)
+        stubGetPrepopAddresses(testRegId, OK, Some(addressSeq))
+
+        val result = await(connector.getPrepopAddresses(testRegId)(headerCarrier))
+
+        result shouldBe Some(PrepopAddresses(addressSeq))
+      }
+      "there aren't any addresses for the specified registration ID" in new PrepopAddressTest {
+        stubGetPrepopAddresses(testRegId, NOT_FOUND, None)
+
+        val result = await(connector.getPrepopAddresses(testRegId)(headerCarrier))
+
+        result shouldBe Some(PrepopAddresses(Seq()))
+      }
+    }
+    "return None" when {
+      "the user is not authorised" in {
+        stubGetPrepopAddresses(testRegId, FORBIDDEN, None)
+
+        val result = await(connector.getPrepopAddresses(testRegId)(headerCarrier))
+
+        result shouldBe None
+      }
+      "an unexpected error occurs" in {
+        stubGetPrepopAddresses(testRegId, INTERNAL_SERVER_ERROR, None)
+
+        val result = await(connector.getPrepopAddresses(testRegId)(headerCarrier))
+
+        result shouldBe None
+      }
+      "the json is invalid" in new PrepopAddressTest {
+        val addressJson = Json.obj()
+        stubGetPrepopAddresses(testRegId, OK, addressJson)
+
+        val result = await(connector.getPrepopAddresses(testRegId)(headerCarrier))
+
+        result shouldBe None
+      }
+    }
+  }
+
+  s"POST /business-registration/$testRegId/addresses" should {
+    "return OK" in new PrepopAddressTest {
+
+      stubPrepopAddressPostResponse(testRegId, OK)
+
+      val postData = Address(None, addrLine1, addrLine2, addrLine3, addrLine4, postcode, country)
+      val result = await(connector.updatePrepopAddress(testRegId, postData))
+
+      result shouldBe true
+    }
+    "return " in new PrepopAddressTest {
+      stubPrepopAddressPostResponse(testRegId, INTERNAL_SERVER_ERROR)
+
+      val postData = Address(None, addrLine1, addrLine2, addrLine3, addrLine4, postcode, country)
+      val result = await(connector.updatePrepopAddress(testRegId, postData))
+
+      result shouldBe false
+    }
+  }
+
+}

--- a/it/itutil/WiremockHelper.scala
+++ b/it/itutil/WiremockHelper.scala
@@ -19,6 +19,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.scalatestplus.play.OneServerPerSuite
 import play.api.libs.ws.WSClient
@@ -68,6 +69,15 @@ trait WiremockHelper {
           withStatus(status).
           withBody(responseBody)
           withHeader(responseHeader._1, responseHeader._2)
+      )
+    )
+
+  def stubPostWithData(url: String, postData: String)(status: Int, responseBody: String): StubMapping =
+    stubFor(post(urlMatching(url))
+      .withRequestBody(equalTo(postData))
+      .willReturn(aResponse()
+        .withStatus(status)
+        .withBody(responseBody)
       )
     )
 

--- a/it/itutil/servicestubs/BusinessRegistrationStub.scala
+++ b/it/itutil/servicestubs/BusinessRegistrationStub.scala
@@ -1,0 +1,44 @@
+
+package itutil.servicestubs
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import connectors.PrepopAddresses
+import itutil.WiremockHelper
+import models.Address
+import org.scalatestplus.play.OneServerPerSuite
+import play.api.libs.json.{JsValue, Json}
+
+trait BusinessRegistrationStub extends WiremockHelper { this: OneServerPerSuite =>
+
+  private def busRegUrl(registrationId: String): String =
+    s"/business-registration/$registrationId/addresses"
+
+  def stubGetPrepopAddresses(registrationId: String,
+                             status: Int,
+                             optAddresses: Option[Seq[Address]]
+                            ): StubMapping = {
+    val addresses = optAddresses match {
+      case Some(addressValues) => addressValues
+      case None => Seq()
+    }
+
+    val jsonBody = Json.stringify(Json.toJson(PrepopAddresses(addresses)))
+    stubGet(busRegUrl(registrationId), status, jsonBody)
+  }
+
+  def stubGetPrepopAddresses(registrationId: String,
+                             status: Int,
+                             jsonAddress: JsValue
+                            ): StubMapping = {
+
+    stubGet(busRegUrl(registrationId), status, Json.stringify(jsonAddress))
+  }
+
+  def stubPrepopAddressPostResponse(registrationId: String,
+                                    status: Int
+                                   ): StubMapping = {
+
+    stubPost(busRegUrl(registrationId), status, responseBody = "")
+  }
+
+}

--- a/test/mocks/AccountingServiceMock.scala
+++ b/test/mocks/AccountingServiceMock.scala
@@ -41,4 +41,4 @@ trait AccountingServiceMock {
         .thenReturn(Future.successful(accountingDetailsResponse))
     }
   }
-  }
+}


### PR DESCRIPTION
# Add pre-pop address connector

- GET to get a list of pre-pop addresses from business registration
- POST to update a single pre-pop address

Could be improved by creating a custom HttpReads a-la VSU, but kept simple for now to avoid scope creep.

## Checklist

* [x] I've included appropriate tests with any code I've added
* N/A I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
