### PR TITLE
SAR-5267 - Fix flow to allow users to change from 'No' to 'Yes'

### DIFF
--- a/app/services/TakeoverService.scala
+++ b/app/services/TakeoverService.scala
@@ -28,12 +28,14 @@ class TakeoverService @Inject()(takeoverConnector: TakeoverConnector)(implicit e
     takeoverConnector.getTakeoverDetails(registrationId)
 
   def updateReplacingAnotherBusiness(registrationId: String, replacingAnotherBusiness: Boolean)(implicit hc: HeaderCarrier): Future[TakeoverDetails] =
-    if(replacingAnotherBusiness) {
+    if (replacingAnotherBusiness) {
       takeoverConnector.getTakeoverDetails(registrationId) flatMap {
         case None =>
           takeoverConnector.updateTakeoverDetails(registrationId, TakeoverDetails(replacingAnotherBusiness))
-        case Some(takeoverDetails) =>
+        case Some(takeoverDetails) if takeoverDetails.replacingAnotherBusiness == replacingAnotherBusiness =>
           Future.successful(takeoverDetails)
+        case Some(takeoverDetails) =>
+          takeoverConnector.updateTakeoverDetails(registrationId, takeoverDetails.copy(replacingAnotherBusiness = replacingAnotherBusiness))
       }
     } else {
       takeoverConnector.updateTakeoverDetails(registrationId, TakeoverDetails(replacingAnotherBusiness))

--- a/test/services/TakeoverServiceSpec.scala
+++ b/test/services/TakeoverServiceSpec.scala
@@ -49,12 +49,23 @@ class TakeoverServiceSpec extends UnitSpec  {
           await(TestTakeoverService.updateReplacingAnotherBusiness(testRegistrationId, replacingAnotherBusiness = true)) shouldBe expectedTakeoverDetails
         }
       }
-      "the user has previously entered takeover information" should {
+      "the user has previously entered identical takeover information" should {
         "do not update the existing data as it has not changed" in new Setup {
           val existingTakeoverDetails: TakeoverDetails = TakeoverDetails(replacingAnotherBusiness = true, Some(testBusinessName))
           mockGetTakeoverDetails(testRegistrationId)(Future.successful(Some(existingTakeoverDetails)))
 
           await(TestTakeoverService.updateReplacingAnotherBusiness(testRegistrationId, replacingAnotherBusiness = true)) shouldBe existingTakeoverDetails
+        }
+      }
+      "the user has previously entered different takeover information" should {
+        "update the existing data" in new Setup {
+          val existingTakeoverDetails: TakeoverDetails = TakeoverDetails(replacingAnotherBusiness = false, Some(testBusinessName))
+          mockGetTakeoverDetails(testRegistrationId)(Future.successful(Some(existingTakeoverDetails)))
+
+          val expectedTakeoverDetails: TakeoverDetails = TakeoverDetails(replacingAnotherBusiness = true, Some(testBusinessName))
+          mockUpdateTakeoverDetails(testRegistrationId, expectedTakeoverDetails)(Future.successful(expectedTakeoverDetails))
+
+          await(TestTakeoverService.updateReplacingAnotherBusiness(testRegistrationId, replacingAnotherBusiness = true)) shouldBe expectedTakeoverDetails
         }
       }
     }


### PR DESCRIPTION
Bug fix 

Allowing users to select 'No' then 'Yes' on replacing another business.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
