### PR TITLE
[SAR-10653] Refactor so that table is only rendered when not 'NOT_STARTED'

### DIFF
--- a/app/views/dashboard/displayRegistrationStatus.scala.html
+++ b/app/views/dashboard/displayRegistrationStatus.scala.html
@@ -22,49 +22,60 @@
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.table.HeadCell
 @import uk.gov.hmrc.govukfrontend.views.Aliases.Text
 
-@this(govukTable : GovukTable,
-        links: components.link)
-
+@this(
+        govukTable : GovukTable,
+        links: components.link
+)
 
 @(dash: ServiceDashboard, prefixHtmlId: String)(implicit request: Request[_], messages: Messages)
 
-@notStartedText(id: String) = @{
-    links(dash.links.startURL, id match {
-        case "payeRegUrl" =>{"page.reg.Dashboard.registerTextForPAYE"}
-        case "vatRegUrl" => {"page.reg.Dashboard.registerText"}
-    }
-    )
+@notStartedText(id: String) = {
+    <div class="govuk-!-margin-bottom-10">
+        @links(
+            dash.links.startURL,
+            id match {
+                case "payeRegUrl" => "page.reg.Dashboard.registerTextForPAYE"
+                case "vatRegUrl" => "page.reg.Dashboard.registerText"
+            },
+            Some(s"${prefixHtmlId}StatusText")
+        )
+    </div>
 }
 
-@govukTable(Table(
-    head = Some(Seq(
-        HeadCell(
-            content = HtmlContent(
-                if(dash.status != NOT_STARTED) {
-                    messages("page.reg.Dashboard.status")
-                } else messages(notStartedText(s"${prefixHtmlId}RegUrl").toString())
+@renderStatusTable = {
+
+    @govukTable(Table(
+        head = Some(Seq(
+            HeadCell(
+                content = HtmlContent(messages("page.reg.Dashboard.status")),
+                classes = "govuk-!-width-one-half"
             ),
-            attributes = if(dash.status == NOT_STARTED) {Map("id" -> s"${prefixHtmlId}StatusText")} else Map(),
-            classes = "govuk-!-width-one-half"
-        ),
-        HeadCell(
-            content = HtmlContent(
-                dash.status match {
-                    case NOT_ELIGIBLE => Messages("page.reg.Dashboard.PAYE.notEligible")
-                    case NOT_STARTED => ""
-                    case "draft" | "locked" => Messages("page.reg.Dashboard.status.incomplete")
-                    case "held" => Messages("page.reg.Dashboard.status.pending")
-                    case "submitted" => Messages("page.reg.Dashboard.status.submitted")
-                    case "acknowledged" => Messages("page.reg.Dashboard.status.acknowledged")
-                    case "invalid" => Messages("page.reg.Dashboard.status.incomplete")
-                    case "rejected" => Messages("page.reg.Dashboard.status.rejected")
-                    case NOT_ENABLED => {""}
-                    case UNAVAILABLE => Messages("page.reg.Dashboard.status.unavailable")
-                }
-            ), classes = "govuk-!-width-one-half", attributes = Map("id" -> s"${prefixHtmlId}StatusText"))
-        )
-    ),
-    captionClasses = "govuk-table__caption--m",
-    firstCellIsHeader = false,
-    classes = "govuk-!-margin-0"
-))
+            HeadCell(
+                content = HtmlContent(
+                    dash.status match {
+                        case NOT_ELIGIBLE => Messages("page.reg.Dashboard.PAYE.notEligible")
+                        case "draft" | "locked" => Messages("page.reg.Dashboard.status.incomplete")
+                        case "held" => Messages("page.reg.Dashboard.status.pending")
+                        case "submitted" => Messages("page.reg.Dashboard.status.submitted")
+                        case "acknowledged" => Messages("page.reg.Dashboard.status.acknowledged")
+                        case "invalid" => Messages("page.reg.Dashboard.status.incomplete")
+                        case "rejected" => Messages("page.reg.Dashboard.status.rejected")
+                        case NOT_ENABLED => ""
+                        case UNAVAILABLE => Messages("page.reg.Dashboard.status.unavailable")
+                    }
+                ),
+                classes = "govuk-!-width-one-half",
+                attributes = Map("id" -> s"${prefixHtmlId}StatusText"))
+        )),
+        captionClasses = "govuk-table__caption--m",
+        firstCellIsHeader = false,
+        classes = "govuk-!-margin-0"
+    ))
+}
+
+@{
+    dash.status match {
+        case NOT_STARTED => notStartedText(s"${prefixHtmlId}RegUrl")
+        case _ => renderStatusTable
+    }
+}

--- a/app/views/templates/layout.scala.html
+++ b/app/views/templates/layout.scala.html
@@ -50,7 +50,9 @@ standardBetaBanner: StandardBetaBanner
 }
 
 @content = {
+    <div class="govuk-body">
        @contentBlock
+    </div>
 
     <div class="govuk-body">
         <a lang="en" hreflang="en" class="govuk-link " target="_blank" href="@{


### PR DESCRIPTION
Also fixes: SAR-10654

**NOTE:** At somepoint, this dashboard requires a much larger refactor. As it uses multiple table instances to render the PAYE Status - rather than having a Table with headers which then contains multiple rows for the different information needed. This is a much bigger change though and outside the scope of this ticket.

**Before this change:**
![Screenshot 2022-10-10 at 16 19 38](https://user-images.githubusercontent.com/16954819/194905452-fda95c49-75cc-4b47-a96a-62f69f954efd.png)

**After this change:**
![Screenshot 2022-10-10 at 16 18 50](https://user-images.githubusercontent.com/16954819/194905492-bed98664-f360-4049-b38f-03b0212a7ced.png)


