### PR TITLE
[SAR-10858] Added service to call connector

### DIFF
--- a/app/services/LanguageService.scala
+++ b/app/services/LanguageService.scala
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-package models
+package services
 
+import connectors.CompanyRegistrationConnector
+import models.Language
 import play.api.i18n.Lang
-import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.http.HeaderCarrier
 
-case class Language(code: String)
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
 
-object Language {
+class LanguageService @Inject()(compRegConnector: CompanyRegistrationConnector) {
 
-  def apply(lang: Lang): Language = Language(lang.code)
+  def updateLanguage(regId: String, lang: Lang)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Boolean] =
+    compRegConnector.updateLanguage(regId, Language(lang))
 
-  implicit val fmt: Format[Language] = Json.format[Language]
 }

--- a/test/models/LanguageSpec.scala
+++ b/test/models/LanguageSpec.scala
@@ -18,6 +18,7 @@ package models
 
 import config.LangConstants
 import helpers.SCRSSpec
+import play.api.i18n.Lang
 import play.api.libs.json.Json
 
 class LanguageSpec extends SCRSSpec {
@@ -33,6 +34,10 @@ class LanguageSpec extends SCRSSpec {
 
     "deserialize from JSON correctly" in {
       languageJson.as[Language] mustBe language
+    }
+
+    "be able to be constructed from a Lang instance" in {
+      Language(Lang(LangConstants.english)) mustBe language
     }
   }
 }

--- a/test/services/LanguageServiceSpec.scala
+++ b/test/services/LanguageServiceSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import config.LangConstants
+import helpers.SCRSSpec
+import models.Language
+import org.mockito.ArgumentMatchers.{eq => eqTo}
+import org.mockito.Mockito.when
+import play.api.i18n.Lang
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class LanguageServiceSpec extends SCRSSpec {
+
+  val regId = "reg12345"
+  val lang = Lang(LangConstants.english)
+
+  implicit val ec = ExecutionContext.Implicits.global
+
+  object TestLanguageService extends LanguageService(mockCompanyRegistrationConnector)
+
+  "LanguageService" when {
+
+    "calling .updateLanguage(regId: String, lang: Lang)" must {
+
+      "return true when call to update Language is successful" in {
+
+        when(mockCompanyRegistrationConnector.updateLanguage(eqTo(regId), eqTo(Language(lang)))(eqTo(hc), eqTo(ec)))
+          .thenReturn(Future.successful(true))
+
+        await(TestLanguageService.updateLanguage(regId, lang)) mustBe true
+      }
+
+      "throw exception if Future unexpectedly fails" in { //note, this should never happen as a recover block exists within the connector
+
+        when(mockCompanyRegistrationConnector.updateLanguage(eqTo(regId), eqTo(Language(lang)))(eqTo(hc), eqTo(ec)))
+          .thenReturn(Future.failed(new Exception("bang")))
+
+        intercept[Exception](await(TestLanguageService.updateLanguage(regId, lang))).getMessage mustBe "bang"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Noddy proxy service almost, but translates the `Lang` instance to a `Language` model via a constructor on the models companion object.