### PR TITLE
DL-14430 Added Cache_Control header to the renew session response

### DIFF
--- a/it/test/www/SignInOutControllerISpec.scala
+++ b/it/test/www/SignInOutControllerISpec.scala
@@ -480,6 +480,7 @@ class SignInOutControllerISpec extends IntegrationSpecBase with LoginStub with R
       response.status mustBe 200
       response.header("Content-Type") mustBe Some("image/jpeg")
       response.header("Content-Disposition") mustBe Some("""inline; filename="renewSession.jpg"""")
+      response.header(HeaderNames.CACHE_CONTROL) mustBe Some("no-cache,no-store,max-age=0")
 
       val request = getPUTRequestJsonBody(s"/keystore/company-registration-frontend/$SessionId/data/lastActionTimestamp")
       request.as[String] mustBe LocalDate.now.toString
@@ -495,6 +496,7 @@ class SignInOutControllerISpec extends IntegrationSpecBase with LoginStub with R
         .get())
 
       response.status mustBe 500
+      response.header(HeaderNames.CACHE_CONTROL) mustBe Some("no-cache,no-store,max-age=0")
     }
   }
 }

--- a/test/controllers/SignInOutControllerSpec.scala
+++ b/test/controllers/SignInOutControllerSpec.scala
@@ -27,6 +27,7 @@ import models.{Email, ThrottleResponse}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.http.HeaderNames.CACHE_CONTROL
 import play.api.libs.json.Json
 import play.api.mvc.{MessagesControllerComponents, Results}
 import play.api.test.FakeRequest
@@ -462,6 +463,7 @@ class SignInOutControllerSpec extends SCRSSpec
         await(a).header.headers.toString().contains("""renewSession.jpg""") mustBe true
         header("Access-Control-Allow-Origin", a) mustBe None
         header("Access-Control-Allow-Credentials", a) mustBe None
+        header(CACHE_CONTROL, a) mustBe Some("no-cache,no-store,max-age=0")
       }
     }
 
@@ -474,6 +476,7 @@ class SignInOutControllerSpec extends SCRSSpec
         status(a) mustBe 200
         header("Access-Control-Allow-Origin", a) mustBe Some("http://localhost:12345")
         header("Access-Control-Allow-Credentials", a) mustBe Some("true")
+        header(CACHE_CONTROL, a) mustBe Some("no-cache,no-store,max-age=0")
       }
     }
   }


### PR DESCRIPTION
# DL-14430 Fix to ensure that the renew-session call has a Cache-Control HTTP header

**Bug fix**

The renew-session call is instigated from Companies House to improve users experience by ensuring that as they transition between pages on the CH incorporation service, the HMRC side of the SCRS service has a refreshed token. If this isn't done then after 15 minutes at CH, the users session at HMRC will have timed out and they would need to log back in to continue the journey.

Without the Cache-Control header, it's ambiguous as to what various caches will do, and there has been a recent example of a response without the header being cached for a short period - which is not something that should happen for this request.

The fix is to include the standard Cache-Control header, which is pulled from the CacheControlFilter provided by the bootstrap library, which will assert that the response must not be cached.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
