### PR TITLE
Added affinityType=organisation to sign in url

### DIFF
--- a/app/controllers/auth/AuthenticatedController.scala
+++ b/app/controllers/auth/AuthenticatedController.scala
@@ -111,6 +111,7 @@ trait AuthenticatedController extends FrontendBaseController with AuthorisedFunc
   lazy val origin: String = appConfig.servicesConfig.getString("appName")
 
   def loginParams(hoID: Option[String], payload: Option[String]) = Map(
+    "accountType" -> Seq("organisation"),
     "continue_url" -> Seq(appConfig.continueURL(hoID, payload)),
     "origin" -> Seq(origin)
   )

--- a/test/controllers/RegistrationEmailConfirmationControllerSpec.scala
+++ b/test/controllers/RegistrationEmailConfirmationControllerSpec.scala
@@ -128,7 +128,7 @@ class RegistrationEmailConfirmationControllerSpec extends SCRSSpec with GuiceOne
       showWithUnauthorisedUser(TestController.show) {
         result =>
           status(result) mustBe SEE_OTHER
-          redirectLocation(result) mustBe Some("http://localhost:9553/bas-gateway/sign-in?continue_url=http%3A%2F%2Flocalhost%3A9970%2Fregister-your-company%2Fpost-sign-in&origin=company-registration-frontend")
+          redirectLocation(result) mustBe Some("http://localhost:9553/bas-gateway/sign-in?accountType=organisation&continue_url=http%3A%2F%2Flocalhost%3A9970%2Fregister-your-company%2Fpost-sign-in&origin=company-registration-frontend")
       }
     }
   }

--- a/test/controllers/auth/AuthFunctionSpec.scala
+++ b/test/controllers/auth/AuthFunctionSpec.scala
@@ -317,7 +317,7 @@ class AuthFunctionSpec extends SCRSSpec with PayloadFixture with GuiceOneAppPerS
         s"$test redirect to sign in  with postsignin as continue url for $ex" in new Setup {
           override val controllerComponents = app.injector.instanceOf[ControllerComponents]
           Try(throw AuthorisationException.fromString(ex))
-            .recover(authFunc.authErrorHandling()).get.header.headers(HeaderNames.LOCATION) mustBe "http://localhost:9553/bas-gateway/sign-in?continue_url=http%3A%2F%2Flocalhost%3A9970%2Fregister-your-company%2Fpost-sign-in&origin=company-registration-frontend"
+            .recover(authFunc.authErrorHandling()).get.header.headers(HeaderNames.LOCATION) mustBe "http://localhost:9553/bas-gateway/sign-in?accountType=organisation&continue_url=http%3A%2F%2Flocalhost%3A9970%2Fregister-your-company%2Fpost-sign-in&origin=company-registration-frontend"
         }
     }
   }

--- a/test/fixtures/LoginFixture.scala
+++ b/test/fixtures/LoginFixture.scala
@@ -19,6 +19,6 @@ package fixtures
 import java.net.URLEncoder
 
 trait LoginFixture {
-  lazy val authUrl = s"http://localhost:9553/bas-gateway/sign-in?continue_url=${URLEncoder.encode(s"http://localhost:9970/register-your-company/post-sign-in", "UTF-8")}&origin=company-registration-frontend"
-  def authUrl(handOffID: String, payload: String) = s"http://localhost:9553/bas-gateway/sign-in?continue_url=${URLEncoder.encode(s"http://localhost:9970/register-your-company/post-sign-in?handOffID=$handOffID&payload=$payload", "UTF-8")}&origin=company-registration-frontend"
+  lazy val authUrl = s"http://localhost:9553/bas-gateway/sign-in?accountType=organisation&continue_url=${URLEncoder.encode(s"http://localhost:9970/register-your-company/post-sign-in", "UTF-8")}&origin=company-registration-frontend"
+  def authUrl(handOffID: String, payload: String) = s"http://localhost:9553/bas-gateway/sign-in?accountType=organisation&continue_url=${URLEncoder.encode(s"http://localhost:9970/register-your-company/post-sign-in?handOffID=$handOffID&payload=$payload", "UTF-8")}&origin=company-registration-frontend"
 }


### PR DESCRIPTION
# Adding Organisation affinity to login requests

**Bug fix**

As [can be seen in config](https://github.com/hmrc/company-registration-frontend/blob/main/conf/application.conf#L141), we used to correctly pass the affinity to group to Auth. It was removed by accident when we moved away from CA (company auth).

We can still see the usage of this query parameter elsewhere in SCRS, [example from PAYE](https://github.com/hmrc/paye-registration-frontend/blob/35950079656ef0e108c5b71d957ea8569773f6f4/conf/application.conf#L113)

And here is an example with [both continueURL and affinityType on bas-gateway on TAI](https://github.com/hmrc/tai-frontend/blob/aa47d26c48919b8ac00ef63edea565fb0baec58d/app/controllers/UnauthorisedController.scala#L70)

This change simply updates our parameters to include affinityType, see tests.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
